### PR TITLE
Implement Huffman encoding

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,11 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        externalNativeBuild {
+            cmake {
+                cppFlags += ""
+            }
+        }
     }
 
     buildTypes {
@@ -36,6 +41,12 @@ android {
     }
     buildFeatures {
         compose = true
+    }
+    externalNativeBuild {
+        cmake {
+            path = file("src/main/cpp/CMakeLists.txt")
+            version = "3.22.1"
+        }
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.material.icons.extended)
+    implementation(libs.androidx.datastore.preferences)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,6 +18,11 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {
+                // CLI arguments for CMake
+                arguments += "-DLLAMA_BUILD_COMMON=ON"
+                arguments += "-DCMAKE_BUILD_TYPE=Release"
+
+                // CLI flags for C++ compiler called by CMake
                 cppFlags += ""
             }
         }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -12,6 +12,19 @@ cmake_minimum_required(VERSION 3.22.1)
 # build script scope).
 project("hips")
 
+# Include CMake's FetchContent module
+include(FetchContent)
+
+# Declare Git repo to fetch llama.cpp library from (has to be called "llama")
+FetchContent_Declare(
+    llama
+    GIT_REPOSITORY https://github.com/ggerganov/llama.cpp
+    GIT_TAG        master
+)
+
+# Fetch llama.cpp (also provides "common")
+FetchContent_MakeAvailable(llama)
+
 # Creates and names a library, sets it as either STATIC
 # or SHARED, and provides the relative paths to its source code.
 # You can define multiple libraries, and CMake builds them for you.
@@ -35,4 +48,7 @@ add_library(${CMAKE_PROJECT_NAME} SHARED
 target_link_libraries(${CMAKE_PROJECT_NAME}
     # List libraries link to the target library
     android
-    log)
+    log
+    llama
+    common
+)

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,38 @@
+
+# For more information about using CMake with Android Studio, read the
+# documentation: https://d.android.com/studio/projects/add-native-code.html.
+# For more examples on how to use CMake, see https://github.com/android/ndk-samples.
+
+# Sets the minimum CMake version required for this project.
+cmake_minimum_required(VERSION 3.22.1)
+
+# Declares the project name. The project name can be accessed via ${ PROJECT_NAME},
+# Since this is the top level CMakeLists.txt, the project name is also accessible
+# with ${CMAKE_PROJECT_NAME} (both CMake variables are in-sync within the top level
+# build script scope).
+project("hips")
+
+# Creates and names a library, sets it as either STATIC
+# or SHARED, and provides the relative paths to its source code.
+# You can define multiple libraries, and CMake builds them for you.
+# Gradle automatically packages shared libraries with your APK.
+#
+# In this top level CMakeLists.txt, ${CMAKE_PROJECT_NAME} is used to define
+# the target library name; in the sub-module's CMakeLists.txt, ${PROJECT_NAME}
+# is preferred for the same purpose.
+#
+# In order to load a library into your app from Java/Kotlin, you must call
+# System.loadLibrary() and pass the name of the library defined here;
+# for GameActivity/NativeActivity derived applications, the same library name must be
+# used in the AndroidManifest.xml file.
+add_library(${CMAKE_PROJECT_NAME} SHARED
+    # List C/C++ source files with relative paths to this CMakeLists.txt.
+    hips.cpp)
+
+# Specifies libraries CMake should link to your target library. You
+# can link libraries from various origins, such as libraries defined in this
+# build script, prebuilt third-party libraries, or Android system libraries.
+target_link_libraries(${CMAKE_PROJECT_NAME}
+    # List libraries link to the target library
+    android
+    log)

--- a/app/src/main/cpp/hips.cpp
+++ b/app/src/main/cpp/hips.cpp
@@ -81,3 +81,57 @@ extern "C" JNIEXPORT void JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_unloa
     // Java long is used instead of now invalid C++ pointer, needs to formated as C++ long long to get all 64 bits
     LOGi("Java_org_vonderheidt_hips_utils_LlamaCpp_unloadModel: LLM was unloaded from memory address 0x%llx", jModel);
 }
+
+/**
+ * Function to load the context into memory.
+ *
+ * @param env The JNI environment.
+ * @param thiz Java object this function was called with.
+ * @param jModel Memory address of the LLM.
+ * @return Memory address of the context.
+ */
+extern "C" JNIEXPORT jlong JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_loadCtx(JNIEnv* env, jobject thiz, jlong jModel) {
+    // Similar to loadModel
+
+    // Cast memory address of the LLM from Java long to C++ pointer
+    auto cppModel = reinterpret_cast<llama_model*>(jModel);
+
+    // Use default parameters for the context
+    llama_context_params params = llama_context_default_params();
+
+    // Create context with the LLM (=> context knows its state) and save pointer to it
+    llama_context* cppCtx = llama_new_context_with_model(cppModel, params);
+
+    // Log success or error message
+    if (cppCtx != nullptr) {
+        LOGi("Java_org_vonderheidt_hips_utils_LlamaCpp_loadCtx: Context was loaded into memory at address 0x%lx", reinterpret_cast<u_long>(cppCtx));
+    }
+    else {
+        LOGe("Java_org_vonderheidt_hips_utils_LlamaCpp_loadCtx: Context could not be loaded into memory (address 0x%lx)", reinterpret_cast<u_long>(cppCtx));
+    }
+
+    // Cast C++ pointer to Java long to return it
+    auto jCtx = reinterpret_cast<jlong>(cppCtx);
+
+    return jCtx;
+}
+
+/**
+ * Function to unload the context from memory.
+ *
+ * @param env The JNI environment.
+ * @param thiz Java object this function was called with.
+ * @param jCtx Memory address of the context.
+ */
+extern "C" JNIEXPORT void JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_unloadCtx(JNIEnv* env, jobject thiz, jlong jCtx) {
+    // Similar to unloadModel
+
+    // Cast memory address of context from Java long to C++ pointer
+    auto cppCtx = reinterpret_cast<llama_context*>(jCtx);
+
+    // Unload context from memory
+    llama_free(cppCtx);
+
+    // Log success message
+    LOGi("Java_org_vonderheidt_hips_utils_LlamaCpp_unloadCtx: Context was unloaded from memory address 0x%llx", jCtx);
+}

--- a/app/src/main/cpp/hips.cpp
+++ b/app/src/main/cpp/hips.cpp
@@ -253,6 +253,33 @@ extern "C" JNIEXPORT jstring JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_de
 }
 
 /**
+ * Function to check if a token is a special token.
+ *
+ * @param env The JNI environment.
+ * @param thiz Java object this function was called with.
+ * @param token Token ID to check.
+ * @param jCtx Memory address of the context.
+ * @return Boolean that is true if the token special, false otherwise.
+ */
+extern "C" JNIEXPORT jboolean JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_isSpecial(JNIEnv* env, jobject thiz, jint token, jlong jCtx) {
+    // Cast memory address of the context from Java long to C++ pointer
+    auto cppCtx = reinterpret_cast<llama_context*>(jCtx);
+
+    // Get model the context was created with
+    const llama_model* model = llama_get_model(cppCtx);
+
+    // Check if token is special
+    // Token ID doesn't need casting because jint and llama_token are both just int32_t
+    bool cppIsSpecial = llama_token_is_eog(model, token) || llama_token_is_control(model,token);
+
+    // Cast boolean to return it
+    // static_cast because casting booleans is type safe, unlike reinterpret_cast for casting C++ pointers to Java long
+    auto jIsSpecial = static_cast<jboolean>(cppIsSpecial);
+
+    return jIsSpecial;
+}
+
+/**
  * Function to calculate the logit matrix (i.e. predictions for every token in the prompt).
  *
  * Only the last row of the `n_tokens` x `n_vocab` matrix is actually needed as it contains the logits corresponding to the last token of the prompt.

--- a/app/src/main/cpp/hips.cpp
+++ b/app/src/main/cpp/hips.cpp
@@ -138,6 +138,56 @@ extern "C" JNIEXPORT void JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_unloa
 }
 
 /**
+ * Function to load the sampler into memory.
+ *
+ * Currently only supports greedy sampler for Huffman encoding.
+ *
+ * @param env The JNI environment.
+ * @param thiz Java object this function was called with.
+ * @return Memory address of the sampler.
+ */
+extern "C" JNIEXPORT jlong JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_loadSmpl(JNIEnv* env, jobject thiz) {
+    // Similar to loadModel
+
+    // Initialize greedy sampler (no sampler chain needed when using only a single sampler)
+    llama_sampler* cppSmpl = llama_sampler_init_greedy();
+
+    // Log success or error message
+    if (cppSmpl != nullptr) {
+        LOGi("Java_org_vonderheidt_hips_utils_LlamaCpp_loadSmpl: Greedy sampler was loaded into memory at address 0x%lx", reinterpret_cast<u_long>(cppSmpl));
+    }
+    else {
+        LOGe("Java_org_vonderheidt_hips_utils_LlamaCpp_loadSmpl: Greedy sampler could not be loaded into memory (address 0x%lx)", reinterpret_cast<u_long>(cppSmpl));
+    }
+
+    // Convert C++ pointer to Java long to return it
+    auto jSmpl = reinterpret_cast<jlong>(cppSmpl);
+
+    return jSmpl;
+}
+
+/**
+ * Function to unload the sampler from memory.
+ *
+ * @param env The JNI environment.
+ * @param thiz Java object this function was called with.
+ * @param jSmpl Memory address of the sampler.
+ */
+extern "C" JNIEXPORT void JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_unloadSmpl(JNIEnv* env, jobject thiz, jlong jSmpl) {
+    // Similar to unloadModel
+
+    // Cast memory address of sampler from Java long to C++ pointer
+    auto cppSmpl = reinterpret_cast<llama_sampler*>(jSmpl);
+
+    // Unload sampler from memory
+    // llama.cpp docs: "important: do not free if the sampler has been added to a llama_sampler_chain (via llama_sampler_chain_add)" (not the case here)
+    llama_sampler_free(cppSmpl);
+
+    // Log success message
+    LOGi("Java_org_vonderheidt_hips_utils_LlamaCpp_unloadSmpl: Sampler was unloaded from memory address 0x%llx", jSmpl);
+}
+
+/**
  * Function to tokenize a string into an array of token IDs.
  *
  * @param env The JNI environment.

--- a/app/src/main/cpp/hips.cpp
+++ b/app/src/main/cpp/hips.cpp
@@ -74,7 +74,7 @@ extern "C" JNIEXPORT void JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_unloa
     // Cast memory address of LLM from Java long to C++ pointer
     auto cppModel = reinterpret_cast<llama_model*>(jModel);
 
-    // Unload model from memory
+    // Unload LLM from memory
     llama_free_model(cppModel);
 
     // Log success message

--- a/app/src/main/cpp/hips.cpp
+++ b/app/src/main/cpp/hips.cpp
@@ -62,3 +62,22 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_load
 
     return jModel;
 }
+
+/**
+ * Function to unload the LLM from memory.
+ *
+ * @param env The JNI environment.
+ * @param thiz Java object this function was called with.
+ * @param jModel Memory address of the LLM.
+ */
+extern "C" JNIEXPORT void JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_unloadModel(JNIEnv* env, jobject thiz, jlong jModel) {
+    // Cast memory address of LLM from Java long to C++ pointer
+    auto cppModel = reinterpret_cast<llama_model*>(jModel);
+
+    // Unload model from memory
+    llama_free_model(cppModel);
+
+    // Log success message
+    // Java long is used instead of now invalid C++ pointer, needs to formated as C++ long long to get all 64 bits
+    LOGi("Java_org_vonderheidt_hips_utils_LlamaCpp_unloadModel: LLM was unloaded from memory address 0x%llx", jModel);
+}

--- a/app/src/main/cpp/hips.cpp
+++ b/app/src/main/cpp/hips.cpp
@@ -45,7 +45,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_load
     llama_model_params params = llama_model_default_params();
 
     // Load the LLM into memory and save pointer to it
-    llama_model* cppModel = llama_load_model_from_file(cppPath, params);
+    llama_model* cppModel = llama_model_load_from_file(cppPath, params);
 
     // Log success or error message
     // Cast pointer to unsigned long and format it as hex
@@ -77,7 +77,7 @@ extern "C" JNIEXPORT void JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_unloa
     auto cppModel = reinterpret_cast<llama_model*>(jModel);
 
     // Unload LLM from memory
-    llama_free_model(cppModel);
+    llama_model_free(cppModel);
 
     // Log success message
     // Java long is used instead of now invalid C++ pointer, needs to formated as C++ long long to get all 64 bits

--- a/app/src/main/cpp/hips.cpp
+++ b/app/src/main/cpp/hips.cpp
@@ -170,3 +170,33 @@ extern "C" JNIEXPORT jintArray JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_
 
     return jTokens;
 }
+
+/**
+ * Function to detokenize an array of token IDs into a string.
+ *
+ * @param env The JNI environment.
+ * @param thiz Java object this function was called with.
+ * @param jTokens Array of token IDs to be detokenized.
+ * @param jCtx Memory address of the context.
+ * @return Detokenization as a string.
+ */
+extern "C" JNIEXPORT jstring JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_detokenize(JNIEnv* env, jobject thiz, jintArray jTokens, jlong jCtx) {
+    // Cast memory address of the context from Java long to C++ pointer
+    auto cppCtx = reinterpret_cast<llama_context*>(jCtx);
+
+    // Initialize C++ array for token IDs and fill it
+    jsize jTokensSize = env -> GetArrayLength(jTokens);
+
+    llama_tokens cppTokens(jTokensSize);
+
+    env -> GetIntArrayRegion(jTokens, 0, jTokensSize, reinterpret_cast<jint*>(cppTokens.data()));
+
+    // Detokenize array of tokens to C++ string, hide special tokens to get clean output
+    // See common.cpp: common_detokenize calls llama_detokenize
+    std::basic_string<char> cppString = common_detokenize(cppCtx, cppTokens, false);
+
+    // Convert C++ string to Java string and return it
+    jstring jString = env -> NewStringUTF(cppString.c_str());
+
+    return jString;
+}

--- a/app/src/main/cpp/hips.cpp
+++ b/app/src/main/cpp/hips.cpp
@@ -1,0 +1,17 @@
+// Write C++ code here.
+//
+// Do not forget to dynamically load the C++ library into your application.
+//
+// For instance,
+//
+// In MainActivity.java:
+//    static {
+//       System.loadLibrary("hips");
+//    }
+//
+// Or, in MainActivity.kt:
+//    companion object {
+//      init {
+//         System.loadLibrary("hips")
+//      }
+//    }

--- a/app/src/main/cpp/hips.cpp
+++ b/app/src/main/cpp/hips.cpp
@@ -15,3 +15,50 @@
 //         System.loadLibrary("hips")
 //      }
 //    }
+
+// Notation: <system libs>, "user libs"
+#include <android/log.h>
+#include <jni.h>
+#include "llama.h"
+
+#define TAG "hips.cpp"                                                              // Logcat tag to identify entries from hips.cpp
+#define LOGi(...) __android_log_print(ANDROID_LOG_INFO, TAG, __VA_ARGS__)           // Log info message
+#define LOGe(...) __android_log_print(ANDROID_LOG_ERROR, TAG, __VA_ARGS__)          // Log error message
+
+/**
+ * Function to load the LLM into memory.
+ *
+ * @param env The JNI environment.
+ * @param thiz Java object this function was called with.
+ * @param jPath Path to the LLM (.gguf file).
+ * @return Memory address of the LLM.
+ */
+extern "C" JNIEXPORT jlong JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_loadModel(JNIEnv* env, jobject thiz, jstring jPath) {
+    // Convert path to LLM from Java string to C++ string using the JNI environment
+    // Set isCopy == true to copy Java string so it doesn't get overwritten in memory
+    jboolean isCopy = true;
+    const char* cppPath = env -> GetStringUTFChars(jPath, &isCopy);
+
+    // Use the LLM with default parameters
+    llama_model_params params = llama_model_default_params();
+
+    // Load the LLM into memory and save pointer to it
+    llama_model* cppModel = llama_load_model_from_file(cppPath, params);
+
+    // Log success or error message
+    // Cast pointer to unsigned long and format it as hex
+    if (cppModel != nullptr) {
+        LOGi("Java_org_vonderheidt_hips_utils_LlamaCpp_loadModel: LLM from %s was loaded into memory at address 0x%lx", cppPath, reinterpret_cast<u_long>(cppModel));
+    }
+    else {
+        LOGe("Java_org_vonderheidt_hips_utils_LlamaCpp_loadModel: LLM from %s could not be loaded into memory (address 0x%lx)", cppPath, reinterpret_cast<u_long>(cppModel));
+    }
+
+    // Release the memory allocated to the C++ path
+    env -> ReleaseStringUTFChars(jPath, cppPath);
+
+    // Cast C++ pointer (64 bit memory address) to Java long (also 64 bit) to return it via JNI
+    auto jModel = reinterpret_cast<jlong>(cppModel);
+
+    return jModel;
+}

--- a/app/src/main/java/org/vonderheidt/hips/MainActivity.kt
+++ b/app/src/main/java/org/vonderheidt/hips/MainActivity.kt
@@ -7,6 +7,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
+import org.vonderheidt.hips.data.HiPSDataStore
 import org.vonderheidt.hips.navigation.SetupNavGraph
 import org.vonderheidt.hips.ui.theme.HiPSTheme
 
@@ -32,6 +35,11 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+
+        // Instantiate DataStore on app startup and read stored settings
+        // Writes default settings to DataStore if app was just installed
+        HiPSDataStore.startInstance(applicationContext)
+        lifecycleScope.launch { HiPSDataStore.readSettings() }
     }
 
     // Load C++ libraries

--- a/app/src/main/java/org/vonderheidt/hips/MainActivity.kt
+++ b/app/src/main/java/org/vonderheidt/hips/MainActivity.kt
@@ -33,4 +33,11 @@ class MainActivity : ComponentActivity() {
             }
         }
     }
+
+    // Load C++ libraries
+    companion object {
+        init {
+            System.loadLibrary("hips")
+        }
+    }
 }

--- a/app/src/main/java/org/vonderheidt/hips/data/HiPSDataStore.kt
+++ b/app/src/main/java/org/vonderheidt/hips/data/HiPSDataStore.kt
@@ -1,0 +1,106 @@
+package org.vonderheidt.hips.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.floatPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import org.vonderheidt.hips.utils.ConversionMode
+import org.vonderheidt.hips.utils.SteganographyMode
+
+/**
+ * Object (i.e. singleton class) to represent the DataStore instance.
+ */
+object HiPSDataStore {
+    // DataStore can be found under /data/data/org.vonderheidt.hips/files/datastore/settings.preferences_pb
+    // Is a binary ProtoBuf file even though Preferences DataStore is used
+    private val Context.dataStore by preferencesDataStore(name = "settings")
+
+    // Define the data type of the values for each setting by declaring the corresponding keys
+    private val conversionMode = stringPreferencesKey("conversionMode")
+    private val steganographyMode = stringPreferencesKey("steganographyMode")
+    private val temperature = floatPreferencesKey("temperature")
+    private val blockSize = intPreferencesKey("blockSize")
+    private val bitsPerToken = intPreferencesKey("bitsPerToken")
+
+    // Annotate the variable referencing the DataStore instance as volatile so that r/w to it is atomic and immediately visible to all threads
+    // Avoids race conditions, i.e. multiple threads trying to start the DataStore simultaneously
+    @Volatile
+    private var instance: DataStore<Preferences>? = null
+
+    /**
+     * Function to start the DataStore instance in a thread-safe manner.
+     *
+     * Doesn't return anything as the HiPSDataStore object stores everything internally.
+     *
+     * @param context Application context.
+     */
+    fun startInstance(context: Context) {
+        // If the instance is already started, there is nothing to do
+        if (instance != null) {
+            return
+        }
+
+        // Otherwise, instantiate the DataStore
+        // Synchronized allows only one thread to execute the code inside {...}, so other threads can't instantiate it simultaneously
+        synchronized(this) {
+            if (instance == null) {
+                instance = context.dataStore
+            }
+        }
+    }
+
+    /**
+     * Function to read the settings from the DataStore.
+     */
+    suspend fun readSettings() {
+        // Instance can be asserted not null because startInstance initializes it in MainActivity (i.e. on app startup)
+        instance!!.data.map { settings ->
+            val conversionMode = settings[conversionMode]
+            val steganographyMode = settings[steganographyMode]
+            val temperature = settings[temperature]
+            val blockSize = settings[blockSize]
+            val bitsPerToken = settings[bitsPerToken]
+
+            // See if any settings are currently stored by checking for null values
+            val isInitialized = conversionMode != null
+                    && steganographyMode != null
+                    && temperature != null
+                    && blockSize != null
+                    && bitsPerToken != null
+
+            // If any settings are stored, return them via .first()
+            if (isInitialized) {
+                // Can be asserted not null because of check with isInitialized
+                Settings.conversionMode = ConversionMode.valueOf(conversionMode!!)
+                Settings.steganographyMode = SteganographyMode.valueOf(steganographyMode!!)
+                Settings.temperature = temperature!!
+                Settings.blockSize = blockSize!!
+                Settings.bitsPerToken = bitsPerToken!!
+            }
+            // Otherwise (i.e. upon installation of this app), store default settings and return them
+            else {
+                writeSettings()
+            }
+        }.first()
+    }
+
+    /**
+     * Function to write the settings to the DataStore.
+     */
+    suspend fun writeSettings() {
+        // Instance can be asserted not null because startInstance initializes it in MainActivity (i.e. on app startup)
+        instance!!.edit { settings ->
+            settings[conversionMode] = Settings.conversionMode.name
+            settings[steganographyMode] = Settings.steganographyMode.name
+            settings[temperature] = Settings.temperature
+            settings[blockSize] = Settings.blockSize
+            settings[bitsPerToken] = Settings.bitsPerToken
+        }
+    }
+}

--- a/app/src/main/java/org/vonderheidt/hips/data/Settings.kt
+++ b/app/src/main/java/org/vonderheidt/hips/data/Settings.kt
@@ -1,0 +1,15 @@
+package org.vonderheidt.hips.data
+
+import org.vonderheidt.hips.utils.ConversionMode
+import org.vonderheidt.hips.utils.SteganographyMode
+
+/**
+ * Object (i.e. singleton class) that represents the user settings. Holds default values to be set upon installation of this app.
+ */
+object Settings {
+    var conversionMode: ConversionMode = ConversionMode.Arithmetic
+    var steganographyMode: SteganographyMode = SteganographyMode.Arithmetic
+    var temperature: Float = 0.9f
+    var blockSize: Int = 3
+    var bitsPerToken: Int = 3
+}

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/HomeScreen.kt
@@ -53,11 +53,10 @@ import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import kotlinx.coroutines.launch
-import org.vonderheidt.hips.utils.decode
-import org.vonderheidt.hips.utils.encode
 import org.vonderheidt.hips.navigation.Screen
 import org.vonderheidt.hips.ui.theme.HiPSTheme
 import org.vonderheidt.hips.utils.LLM
+import org.vonderheidt.hips.utils.Steganography
 
 /**
  * Function that defines contents of the home screen.
@@ -256,10 +255,10 @@ fun HomeScreen(navController: NavController, modifier: Modifier) {
                     // Call encode or decode function as coroutine, depending on mode selected
                     coroutineScope.launch {
                         if (selectedMode == 0) {
-                            coverText = encode(context, secretMessage)
+                            coverText = Steganography.encode(context, secretMessage)
                         }
                         else {
-                            secretMessage = decode(context, coverText)
+                            secretMessage = Steganography.decode(context, coverText)
                         }
 
                         // Hide loading animation, show new output only when encode or decode is finished

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/HomeScreen.kt
@@ -57,6 +57,7 @@ import kotlinx.coroutines.launch
 import org.vonderheidt.hips.navigation.Screen
 import org.vonderheidt.hips.ui.theme.HiPSTheme
 import org.vonderheidt.hips.utils.LLM
+import org.vonderheidt.hips.utils.LlamaCpp
 import org.vonderheidt.hips.utils.Steganography
 
 /**
@@ -254,6 +255,11 @@ fun HomeScreen(navController: NavController, modifier: Modifier) {
                     // Use Dispatchers.Default since LLM inference is CPU-bound
                     // Keep encapsulation of coroutine vs if-else like this so the loading animation works
                     CoroutineScope(Dispatchers.Default).launch {
+                        // Reset LLM instance on every button press to ensure reproducibility, otherwise ctx before encode and decode would not be the same
+                        // Works when called before this coroutine or inside it, but crashes when called inside its own coroutine before this one
+                        // Might be desirable to use it with Dispatchers.IO as it is presumably I/O-bound, but seems negligible
+                        LlamaCpp.resetInstance()
+
                         if (selectedMode == 0) {
                             coverText = Steganography.encode(context, secretMessage)
                         }

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/HomeScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -52,6 +51,8 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.vonderheidt.hips.navigation.Screen
 import org.vonderheidt.hips.ui.theme.HiPSTheme
@@ -79,9 +80,6 @@ fun HomeScreen(navController: NavController, modifier: Modifier) {
     // Clipboard
     val currentLocalContext = LocalContext.current
     val clipboardManager = currentLocalContext.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-
-    // Coroutines
-    val coroutineScope = rememberCoroutineScope()
 
     // UI components
     Column(
@@ -253,7 +251,9 @@ fun HomeScreen(navController: NavController, modifier: Modifier) {
                     isLoading = true
 
                     // Call encode or decode function as coroutine, depending on mode selected
-                    coroutineScope.launch {
+                    // Use Dispatchers.Default since LLM inference is CPU-bound
+                    // Keep encapsulation of coroutine vs if-else like this so the loading animation works
+                    CoroutineScope(Dispatchers.Default).launch {
                         if (selectedMode == 0) {
                             coverText = Steganography.encode(context, secretMessage)
                         }

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/HomeScreen.kt
@@ -6,12 +6,15 @@ import android.content.Context
 import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -22,6 +25,7 @@ import androidx.compose.material.icons.outlined.Forum
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material3.Badge
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -53,6 +57,7 @@ import org.vonderheidt.hips.utils.decode
 import org.vonderheidt.hips.utils.encode
 import org.vonderheidt.hips.navigation.Screen
 import org.vonderheidt.hips.ui.theme.HiPSTheme
+import org.vonderheidt.hips.utils.llmDownloaded
 
 /**
  * Function that defines contents of the home screen.
@@ -60,6 +65,7 @@ import org.vonderheidt.hips.ui.theme.HiPSTheme
 @Composable
 fun HomeScreen(navController: NavController, modifier: Modifier) {
     // State variables
+    var llmDownloaded by rememberSaveable { mutableStateOf(llmDownloaded()) }
     var context by rememberSaveable { mutableStateOf("") }
     var secretMessage by rememberSaveable { mutableStateOf("") }
     val modes = listOf("Encode", "Decode")
@@ -100,13 +106,25 @@ fun HomeScreen(navController: NavController, modifier: Modifier) {
             }
 
             // Settings icon
-            IconButton(
-                onClick = { navController.navigate(Screen.Settings.route) }
-            ) {
-                Icon(
-                    imageVector = Icons.Outlined.Settings,
-                    contentDescription = "Settings"
-                )
+            // Use a Box to overlay Badge and IconButton
+            Box {
+                IconButton(
+                    onClick = { navController.navigate(Screen.Settings.route) }
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Settings,
+                        contentDescription = "Settings"
+                    )
+                }
+
+                if (!llmDownloaded) {
+                    Badge(
+                        modifier = modifier
+                            .align(Alignment.TopEnd)
+                            .padding(8.dp)
+                            .size(8.dp)
+                    )
+                }
             }
         }
 

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/HomeScreen.kt
@@ -69,7 +69,7 @@ fun HomeScreen(navController: NavController, modifier: Modifier) {
     var secretMessage by rememberSaveable { mutableStateOf("") }
     val modes = listOf("Encode", "Decode")
     var selectedMode by rememberSaveable { mutableIntStateOf(0) }
-    var outputVisible by rememberSaveable { mutableStateOf(false) }
+    var isOutputVisible by rememberSaveable { mutableStateOf(false) }
     var isLoading by rememberSaveable { mutableStateOf(false) }
     var coverText by rememberSaveable { mutableStateOf("") }
 
@@ -229,7 +229,7 @@ fun HomeScreen(navController: NavController, modifier: Modifier) {
                             selectedMode = index
 
                             // Hide old output when mode is changed
-                            outputVisible = false
+                            isOutputVisible = false
 
                             // Clear both secret message and cover text when mode is changed
                             secretMessage = ""
@@ -249,7 +249,7 @@ fun HomeScreen(navController: NavController, modifier: Modifier) {
             Button(
                 onClick = {
                     // Hide old output when start button is pressed again, show loading animation
-                    outputVisible = false
+                    isOutputVisible = false
                     isLoading = true
 
                     // Call encode or decode function as coroutine, depending on mode selected
@@ -263,7 +263,7 @@ fun HomeScreen(navController: NavController, modifier: Modifier) {
 
                         // Hide loading animation, show new output only when encode or decode is finished
                         isLoading = false
-                        outputVisible = true
+                        isOutputVisible = true
                     }
                 },
                 shape = RoundedCornerShape(4.dp)
@@ -281,7 +281,7 @@ fun HomeScreen(navController: NavController, modifier: Modifier) {
 
         // Output is either cover text or secret message
         // Only show when encode or decode is finished (i.e. also not on app startup)
-        if (outputVisible) {
+        if (isOutputVisible) {
             Spacer(modifier = modifier.height(32.dp))
 
             if (selectedMode == 0) {

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/HomeScreen.kt
@@ -57,7 +57,7 @@ import org.vonderheidt.hips.utils.decode
 import org.vonderheidt.hips.utils.encode
 import org.vonderheidt.hips.navigation.Screen
 import org.vonderheidt.hips.ui.theme.HiPSTheme
-import org.vonderheidt.hips.utils.llmDownloaded
+import org.vonderheidt.hips.utils.LLM
 
 /**
  * Function that defines contents of the home screen.
@@ -65,7 +65,7 @@ import org.vonderheidt.hips.utils.llmDownloaded
 @Composable
 fun HomeScreen(navController: NavController, modifier: Modifier) {
     // State variables
-    var llmDownloaded by rememberSaveable { mutableStateOf(llmDownloaded()) }
+    val isDownloaded by rememberSaveable { mutableStateOf(LLM.isDownloaded()) }
     var context by rememberSaveable { mutableStateOf("") }
     var secretMessage by rememberSaveable { mutableStateOf("") }
     val modes = listOf("Encode", "Decode")
@@ -117,7 +117,7 @@ fun HomeScreen(navController: NavController, modifier: Modifier) {
                     )
                 }
 
-                if (!llmDownloaded) {
+                if (!isDownloaded) {
                     Badge(
                         modifier = modifier
                             .align(Alignment.TopEnd)

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/HomeScreen.kt
@@ -59,7 +59,7 @@ import org.vonderheidt.hips.utils.LLM
 import org.vonderheidt.hips.utils.Steganography
 
 /**
- * Function that defines contents of the home screen.
+ * Function that defines the home screen.
  */
 @Composable
 fun HomeScreen(navController: NavController, modifier: Modifier) {
@@ -326,7 +326,7 @@ fun HomeScreen(navController: NavController, modifier: Modifier) {
 }
 
 /**
- * Function to show preview of the main screen in Android Studio.
+ * Function to show preview of the home screen in Android Studio.
  */
 @Preview(showBackground = true)
 @Composable

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
@@ -57,7 +57,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
     // Scrolling
     val scrollState = rememberScrollState()
 
-    // Links
+    // Download and links
     val currentLocalContext = LocalContext.current
 
     // Coroutines
@@ -137,7 +137,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                 onClick = {
                     if(!llmDownloaded) {
                         coroutineScope.launch {
-                            downloadLLM()
+                            downloadLLM(currentLocalContext)
                             llmDownloaded = true
                         }
                     }

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
@@ -3,6 +3,7 @@ package org.vonderheidt.hips.ui.screens
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -11,11 +12,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.Key
+import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Pause
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.PlayArrow
@@ -25,9 +29,13 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -43,10 +51,14 @@ import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import kotlinx.coroutines.launch
+import org.vonderheidt.hips.data.HiPSDataStore
+import org.vonderheidt.hips.data.Settings
 import org.vonderheidt.hips.navigation.Screen
 import org.vonderheidt.hips.ui.theme.HiPSTheme
+import org.vonderheidt.hips.utils.ConversionMode
 import org.vonderheidt.hips.utils.LLM
 import org.vonderheidt.hips.utils.LlamaCpp
+import org.vonderheidt.hips.utils.SteganographyMode
 
 /**
  * Function that defines the settings screen.
@@ -56,6 +68,11 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
     // State variables
     var isDownloaded by rememberSaveable { mutableStateOf(LLM.isDownloaded()) }
     var isInMemory by rememberSaveable { mutableStateOf(LlamaCpp.isInMemory()) }
+    var selectedConversionMode by rememberSaveable { mutableStateOf(Settings.conversionMode) }
+    var selectedSteganographyMode by rememberSaveable { mutableStateOf(Settings.steganographyMode) }
+    var selectedTemperature by rememberSaveable { mutableFloatStateOf(Settings.temperature) }
+    var selectedBlockSize by rememberSaveable { mutableIntStateOf(Settings.blockSize) }
+    var selectedBitsPerToken by rememberSaveable { mutableIntStateOf(Settings.bitsPerToken) }
 
     // Scrolling
     val scrollState = rememberScrollState()
@@ -188,6 +205,200 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
 
             Spacer(modifier = modifier.height(16.dp))
         }
+
+        // Steganography settings
+        Row(
+            modifier = modifier.fillMaxWidth(0.9f)
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Key,
+                contentDescription = "Steganography settings"
+            )
+
+            Spacer(modifier = modifier.width(16.dp))
+
+            Column {
+                Text(
+                    text = "Steganography",
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold
+                )
+
+                Text(text = "Select how to convert the secret message from string to binary.")
+
+                Spacer(modifier = modifier.height(16.dp))
+
+                // Select conversion mode
+                ConversionMode.entries.toTypedArray().forEach { conversionMode ->
+                    Row(
+                        modifier = modifier
+                            .fillMaxWidth()
+                            .selectable(
+                                // Make the whole row selectable instead of just the button for better accessibility
+                                selected = conversionMode == selectedConversionMode,
+                                onClick = {
+                                    // Update state variable
+                                    selectedConversionMode = conversionMode
+
+                                    // Update DataStore
+                                    Settings.conversionMode = conversionMode
+                                    coroutineScope.launch { HiPSDataStore.writeSettings() }
+                                }
+                            ),
+                        horizontalArrangement = Arrangement.Start,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        RadioButton(
+                            selected = conversionMode == selectedConversionMode,
+                            onClick = {
+                                // Same as row onClick
+                                selectedConversionMode = conversionMode
+
+                                Settings.conversionMode = conversionMode
+                                coroutineScope.launch { HiPSDataStore.writeSettings() }
+                            }
+                        )
+
+                        // Use .toString() instead of .name to get display name
+                        Text(text = conversionMode.toString())
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = modifier.height(16.dp))
+
+        Row(
+            modifier = modifier.fillMaxWidth(0.9f)
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Lock,
+                contentDescription = "Steganography settings"
+            )
+
+            Spacer(modifier = modifier.width(16.dp))
+
+            Column {
+                Text(text = "Select how to encode the secret message into a cover text.")
+
+                Spacer(modifier = modifier.height(16.dp))
+
+                // Select steganography mode
+                SteganographyMode.entries.toTypedArray().forEach { steganographyMode ->
+                    Row(
+                        modifier = modifier
+                            .fillMaxWidth()
+                            .selectable(
+                                // Again, make the whole row selectable
+                                selected = steganographyMode == selectedSteganographyMode,
+                                onClick = {
+                                    // Update state variable
+                                    selectedSteganographyMode = steganographyMode
+
+                                    // Update DataStore
+                                    Settings.steganographyMode = steganographyMode
+                                    coroutineScope.launch { HiPSDataStore.writeSettings() }
+                                }
+                            ),
+                        horizontalArrangement = Arrangement.Start,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        RadioButton(
+                            selected = steganographyMode == selectedSteganographyMode,
+                            onClick = {
+                                // Same as row onClick
+                                selectedSteganographyMode = steganographyMode
+
+                                Settings.steganographyMode = steganographyMode
+                                coroutineScope.launch { HiPSDataStore.writeSettings() }
+                            }
+                        )
+
+                        // Use .toString() instead of .name to get display name
+                        Text(text = steganographyMode.toString())
+                    }
+                }
+
+                Spacer(modifier = modifier.height(16.dp))
+
+                // Specific settings for each steganography mode
+                when (selectedSteganographyMode) {
+                    SteganographyMode.Arithmetic -> {
+                        Text(text = "Set the temperature for token sampling (\"creativity\" of the LLM).")
+
+                        Spacer(modifier = modifier.height(16.dp))
+
+                        Slider(
+                            value = selectedTemperature,
+                            onValueChange = {
+                                // Update state variable
+                                selectedTemperature = it
+
+                                // Update DataStore
+                                Settings.temperature = it
+                                coroutineScope.launch { HiPSDataStore.writeSettings() }
+                            },
+                            valueRange = 0f..2f,
+                            steps = 19
+                        )
+
+                        Spacer(modifier = modifier.height(16.dp))
+
+                        Text(text = "T = $selectedTemperature")
+                    }
+                    SteganographyMode.Bins -> {
+                        Text(text = "Set the number of bins (higher is more efficient, but less coherent).")
+
+                        Spacer(modifier = modifier.height(16.dp))
+
+                        // Slider only allows floats, do int conversion here to abstract it away from state variable
+                        Slider(
+                            value = selectedBlockSize.toFloat(),
+                            onValueChange = {
+                                // Update state variable
+                                selectedBlockSize = it.toInt()
+
+                                // Update DataStore
+                                Settings.blockSize = it.toInt()
+                                coroutineScope.launch { HiPSDataStore.writeSettings() }
+                            },
+                            valueRange = 1f..4f,
+                            steps = 2
+                        )
+
+                        Spacer(modifier = modifier.height(16.dp))
+
+                        Text(text = "n = 2^$selectedBlockSize bins")
+                    }
+                    SteganographyMode.Huffman -> {
+                        Text(text = "Set the bits per token (higher is more efficient, but less coherent).")
+
+                        Spacer(modifier = modifier.height(16.dp))
+
+                        // Again, do int conversion here as slider only allows floats
+                        Slider(
+                            value = selectedBitsPerToken.toFloat(),
+                            onValueChange = {
+                                // Update state variable
+                                selectedBitsPerToken = it.toInt()
+
+                                // Update DataStore
+                                Settings.bitsPerToken = it.toInt()
+                                coroutineScope.launch { HiPSDataStore.writeSettings() }
+                            },
+                            valueRange = 1f..4f,
+                            steps = 2
+                        )
+
+                        Spacer(modifier = modifier.height(16.dp))
+
+                        Text(text = "n = $selectedBitsPerToken bits/token")
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = modifier.height(16.dp))
 
         HorizontalDivider()
 

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -56,6 +57,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
     // State variables
     var isDownloaded by rememberSaveable { mutableStateOf(LLM.isDownloaded()) }
     var isInMemory by rememberSaveable { mutableStateOf(false) }
+    var model by rememberSaveable { mutableLongStateOf(0L) }
 
     // Scrolling
     val scrollState = rememberScrollState()
@@ -171,9 +173,15 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
 
             Button(
                 onClick = {
-                    // Load model in coroutine so app doesn't crash
-                    coroutineScope.launch { LlamaCpp.loadModel() }
-                    isInMemory = true
+                    // Load and unload model in coroutines so app doesn't crash
+                    if (!isInMemory) {
+                        coroutineScope.launch { model = LlamaCpp.loadModel() }
+                        isInMemory = true
+                    }
+                    else {
+                        coroutineScope.launch { LlamaCpp.unloadModel(model) }
+                        isInMemory = false
+                    }
                 },
                 shape = RoundedCornerShape(4.dp)
             ) {

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -40,11 +39,9 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
-import kotlinx.coroutines.launch
 import org.vonderheidt.hips.navigation.Screen
 import org.vonderheidt.hips.ui.theme.HiPSTheme
-import org.vonderheidt.hips.utils.downloadLLM
-import org.vonderheidt.hips.utils.llmDownloaded
+import org.vonderheidt.hips.utils.LLM
 
 /**
  * Function that defines the settings screen.
@@ -52,16 +49,13 @@ import org.vonderheidt.hips.utils.llmDownloaded
 @Composable
 fun SettingsScreen(navController: NavController, modifier: Modifier) {
     // State variables
-    var llmDownloaded by rememberSaveable { mutableStateOf(llmDownloaded()) }
+    var isDownloaded by rememberSaveable { mutableStateOf(LLM.isDownloaded()) }
 
     // Scrolling
     val scrollState = rememberScrollState()
 
     // Download and links
     val currentLocalContext = LocalContext.current
-
-    // Coroutines
-    val coroutineScope = rememberCoroutineScope()
 
     // UI components
     Column(
@@ -98,7 +92,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
         Row(
             modifier = modifier.fillMaxWidth(0.9f)
         ) {
-            if (llmDownloaded) {
+            if (isDownloaded) {
                 Icon(
                     imageVector = Icons.Outlined.CheckCircle,
                     contentDescription = "Check mark"
@@ -120,7 +114,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                     fontWeight = FontWeight.Bold
                 )
 
-                if (llmDownloaded) {
+                if (isDownloaded) {
                     Text(text = "The LLM has been downloaded. You can now start using this app.")
                 }
                 else {
@@ -135,14 +129,12 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
         Row {
             Button(
                 onClick = {
-                    if(!llmDownloaded) {
-                        coroutineScope.launch {
-                            downloadLLM(currentLocalContext)
-                            llmDownloaded = true
-                        }
+                    if(!isDownloaded) {
+                        LLM.download(currentLocalContext)
+                        isDownloaded = true
                     }
                 },
-                enabled = !llmDownloaded,
+                enabled = !isDownloaded,
                 shape = RoundedCornerShape(4.dp)
             ) {
                 Text(text = "Download")

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
@@ -16,7 +16,9 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.Pause
 import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material.icons.outlined.PlayArrow
 import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.material3.Button
@@ -27,6 +29,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -39,9 +42,11 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
+import kotlinx.coroutines.launch
 import org.vonderheidt.hips.navigation.Screen
 import org.vonderheidt.hips.ui.theme.HiPSTheme
 import org.vonderheidt.hips.utils.LLM
+import org.vonderheidt.hips.utils.LlamaCpp
 
 /**
  * Function that defines the settings screen.
@@ -50,12 +55,16 @@ import org.vonderheidt.hips.utils.LLM
 fun SettingsScreen(navController: NavController, modifier: Modifier) {
     // State variables
     var isDownloaded by rememberSaveable { mutableStateOf(LLM.isDownloaded()) }
+    var isInMemory by rememberSaveable { mutableStateOf(false) }
 
     // Scrolling
     val scrollState = rememberScrollState()
 
     // Download and links
     val currentLocalContext = LocalContext.current
+
+    // Coroutines
+    val coroutineScope = rememberCoroutineScope()
 
     // UI components
     Column(
@@ -142,6 +151,37 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
         }
 
         Spacer(modifier = modifier.height(16.dp))
+
+        // Button to load LLM into memory
+        if (isDownloaded) {
+            Row(
+                modifier = modifier.fillMaxWidth(0.9f)
+            ) {
+                Icon(
+                    imageVector = if (!isInMemory) Icons.Outlined.PlayArrow else Icons.Outlined.Pause,
+                    contentDescription = if (!isInMemory) "Load LLM into memory" else "Unload LLM from memory"
+                )
+
+                Spacer(modifier = modifier.width(16.dp))
+
+                Text(text = "The LLM needs to be loaded into memory.")
+            }
+
+            Spacer(modifier = modifier.height(16.dp))
+
+            Button(
+                onClick = {
+                    // Load model in coroutine so app doesn't crash
+                    coroutineScope.launch { LlamaCpp.loadModel() }
+                    isInMemory = true
+                },
+                shape = RoundedCornerShape(4.dp)
+            ) {
+                Text(text = if (!isInMemory) "Start LLM" else "Stop LLM")
+            }
+
+            Spacer(modifier = modifier.height(16.dp))
+        }
 
         HorizontalDivider()
 

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
@@ -174,9 +174,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                     fontWeight = FontWeight.Bold
                 )
 
-                Text(
-                    text = "Tobias Vonderheidt <tobias@vonderheidt.org>"
-                )
+                Text(text = "Tobias Vonderheidt <tobias@vonderheidt.org>")
             }
         }
 
@@ -208,9 +206,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                     fontWeight = FontWeight.Bold
                 )
 
-                Text(
-                    text = "github.com/tobiasvonderheidt/hips"
-                )
+                Text(text = "github.com/tobiasvonderheidt/hips")
             }
         }
 

--- a/app/src/main/java/org/vonderheidt/hips/utils/Arithmetic.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Arithmetic.kt
@@ -1,0 +1,39 @@
+package org.vonderheidt.hips.utils
+
+import kotlinx.coroutines.delay
+import org.vonderheidt.hips.data.Settings
+
+/**
+ * Object (i.e. singleton class) that represents steganography using arithmetic encoding.
+ */
+object Arithmetic {
+    /**
+     * Function to encode (the encrypted binary representation of) the secret message into a cover text using arithmetic encoding.
+     *
+     * Corresponds to Stegasuras method `encode_arithmetic` in `arithmetic.py`.
+     */
+    suspend fun encode(context: String, cipherBits: ByteArray, temperature: Float = Settings.temperature): String {
+        // Wait 5 seconds
+        delay(5000)
+
+        // Return placeholder
+        val coverText = ""
+
+        return coverText
+    }
+
+    /**
+     * Function to decode a cover text into (the encrypted binary representation of) the secret message using arithmetic decoding.
+     *
+     * Corresponds to Stegasuras method `decode_arithmetic` in `arithmetic.py`.
+     */
+    suspend fun decode(context: String, coverText: String, temperature: Float = Settings.temperature): ByteArray {
+        // Wait 5 seconds
+        delay(5000)
+
+        // Return placeholder
+        val cipherBits = ByteArray(size = 0)
+
+        return cipherBits
+    }
+}

--- a/app/src/main/java/org/vonderheidt/hips/utils/Bins.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Bins.kt
@@ -1,0 +1,39 @@
+package org.vonderheidt.hips.utils
+
+import kotlinx.coroutines.delay
+import org.vonderheidt.hips.data.Settings
+
+/**
+ * Object (i.e. singleton class) that represents steganography using bins encoding.
+ */
+object Bins {
+    /**
+     * Function to encode (the encrypted binary representation of) the secret message into a cover text using bins encoding.
+     *
+     * Corresponds to Stegasuras method `encode_block` in `block_baseline.py`.
+     */
+    suspend fun encode(context: String, cipherBits: ByteArray, blockSize: Int = Settings.blockSize): String {
+        // Wait 5 seconds
+        delay(5000)
+
+        // Return placeholder
+        val coverText = ""
+
+        return coverText
+    }
+
+    /**
+     * Function to decode a cover text into (the encrypted binary representation of) the secret message using bins decoding.
+     *
+     * Corresponds to Stegasuras method `decode_block` in `block_baseline.py`.
+     */
+    suspend fun decode(context: String, coverText: String, blockSize: Int = Settings.blockSize): ByteArray {
+        // Wait 5 seconds
+        delay(5000)
+
+        // Return placeholder
+        val cipherBits = ByteArray(size = 0)
+
+        return cipherBits
+    }
+}

--- a/app/src/main/java/org/vonderheidt/hips/utils/ConversionMode.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/ConversionMode.kt
@@ -1,0 +1,20 @@
+package org.vonderheidt.hips.utils
+
+/**
+ * Class to enumerate all conversion modes.
+ *
+ * @param displayName Display name of the conversion mode.
+ */
+enum class ConversionMode(private val displayName: String) {
+    Arithmetic("Arithmetic (recommended)"),
+    UTF8("UTF-8");
+
+    /**
+     * Function to get the display name of the conversion mode.
+     *
+     * @return Display name of the conversion mode.
+     */
+    override fun toString(): String {
+        return displayName
+    }
+}

--- a/app/src/main/java/org/vonderheidt/hips/utils/Crypto.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Crypto.kt
@@ -13,8 +13,8 @@ object Crypto {
         // Wait 5 seconds
         delay(5000)
 
-        // Return placeholder
-        val cipherBits = ByteArray(size = 0)
+        // Skip encryption for now
+        val cipherBits = plainBits
 
         return cipherBits
     }
@@ -26,8 +26,8 @@ object Crypto {
         // Wait 5 seconds
         delay(5000)
 
-        // Return placeholder
-        val plainBits = ByteArray(size = 0)
+        // Skip decryption for now
+        val plainBits = cipherBits
 
         return plainBits
     }

--- a/app/src/main/java/org/vonderheidt/hips/utils/Crypto.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Crypto.kt
@@ -1,0 +1,34 @@
+package org.vonderheidt.hips.utils
+
+import kotlinx.coroutines.delay
+
+/**
+ * Object (i.e. singleton class) that represents encryption and decryption.
+ */
+object Crypto {
+    /**
+     * Function to encrypt plain bits into cipher bits.
+     */
+    suspend fun encrypt(plainBits: ByteArray): ByteArray {
+        // Wait 5 seconds
+        delay(5000)
+
+        // Return placeholder
+        val cipherBits = ByteArray(size = 0)
+
+        return cipherBits
+    }
+
+    /**
+     * Function to decrypt cipher bits into plain bits.
+     */
+    suspend fun decrypt(cipherBits: ByteArray): ByteArray {
+        // Wait 5 seconds
+        delay(5000)
+
+        // Return placeholder
+        val plainBits = ByteArray(size = 0)
+
+        return plainBits
+    }
+}

--- a/app/src/main/java/org/vonderheidt/hips/utils/Format.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Format.kt
@@ -1,0 +1,38 @@
+package org.vonderheidt.hips.utils
+
+/**
+ * Object (i.e. singleton class) that represents various functions for string formatting.
+ */
+object Format {
+    /**
+     * Function to format a ByteArray as a bit string.
+     *
+     * @param byteArray A ByteArray.
+     * @return The bit string.
+     */
+    fun asBitString(byteArray: ByteArray): String {
+        val bitString = byteArray.joinToString(separator = "") { byte ->
+            String.format(format = "%8s", Integer.toBinaryString(byte.toInt() and 0xFF)).replace(oldChar = ' ', newChar = '0')
+        }
+
+        return bitString
+    }
+
+    /**
+     * Function to reverse formatting of a ByteArray as a bit string (i.e. to reverse `Format.asBitString(ByteArray)`).
+     *
+     * @param bitString A bit string.
+     * @return The ByteArray.
+     */
+    fun asByteArray(bitString: String): ByteArray {
+        // Don't assert string length to be a multiple of 8, causes error in Huffman encoding with 3 bits/token
+        val byteArray = ByteArray(size = bitString.length / 8) { index ->
+            val byteString = bitString.substring(startIndex = index * 8, endIndex = (index + 1) * 8)
+            val byte = byteString.toInt(radix = 2).toByte()
+
+            byte
+        }
+
+        return byteArray
+    }
+}

--- a/app/src/main/java/org/vonderheidt/hips/utils/Huffman.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Huffman.kt
@@ -36,4 +36,23 @@ object Huffman {
 
         return cipherBits
     }
+
+    /**
+     * Function to get the top 2^bitsPerToken logits for the last token of the prompt. Keeps track of the corresponding token IDs in a map.
+     *
+     * Parameter `bits_per_word` from Stegasuras was renamed to `bitsPerToken`.
+     *
+     * @param logits Logits for the last token of the prompt (= last row of logits matrix).
+     * @param bitsPerToken Number of bits to encode/decode per cover text token (= height of Huffman tree). Determined by Settings object.
+     * @return Map of top 2^bitsPerToken logits and the corresponding token IDs.
+     */
+    private fun getTopLogits(logits: FloatArray, bitsPerToken: Int = Settings.bitsPerToken): Map<Int, Float> {
+        val topLogits = logits
+            .mapIndexed{ token, logit -> token to logit }   // Convert to List<Pair<Int, Float>> so token IDs won't get lost
+            .sortedByDescending { it.second }               // Sort pairs descending based on logits
+            .take(1 shl bitsPerToken)                    // Take top 2^bitsPerToken pairs
+            .toMap()                                        // Convert to Map<Int, Float> for Huffman tree (ensures there can't be any duplicate token IDs)
+
+        return topLogits
+    }
 }

--- a/app/src/main/java/org/vonderheidt/hips/utils/Huffman.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Huffman.kt
@@ -10,14 +10,89 @@ object Huffman {
     /**
      * Function to encode (the encrypted binary representation of) the secret message into a cover text using Huffman encoding.
      *
-     * Corresponds to Stegasuras method `encode_huffman` in `huffman_baseline.py`.
+     * Corresponds to Stegasuras method `encode_huffman` in `huffman_baseline.py`. Parameter `finish_sent` was removed (<=> is now hard coded to true).
+     *
+     * @param context The context to encode the secret message with.
+     * @param cipherBits The encrypted binary representation of the secret message.
+     * @return A cover text containing the secret message.
      */
-    suspend fun encode(context: String, cipherBits: ByteArray, bitsPerToken: Int = Settings.bitsPerToken): String {
-        // Wait 5 seconds
-        delay(5000)
+    fun encode(context: String, cipherBits: ByteArray): String {
+        // Tokenize context
+        val contextTokens = LlamaCpp.tokenize(context)
 
-        // Return placeholder
-        val coverText = ""
+        // Convert cipher bits to bit string
+        val cipherBitString = Format.asBitString(cipherBits)
+
+        // Initialize array to store cover text tokens
+        var coverTextTokens = intArrayOf()
+
+        // Initialize variables and flags for loop
+        var i = 0
+        var isLastSentenceFinished = false
+
+        var isFirstRun = true                   // llama.cpp batch needs to store context tokens in first run, but only last sampled token in subsequent runs
+        var sampledToken = -1                   // Will always be overwritten with last cover text token
+
+        // Sample tokens until all of bits of secret message are encoded and last sentence is finished
+        while (i < cipherBitString.length || !isLastSentenceFinished) {
+            // Huffman sampling to encode bits of secret message into tokens
+            if (i < cipherBitString.length) {
+                // Call llama.cpp to calculate the logit matrix similar to https://github.com/ggerganov/llama.cpp/blob/master/examples/simple/simple.cpp:
+                // Needs only next tokens to be processed to store in a batch, i.e. contextTokens in first run and last sampled token in subsequent runs, rest is managed internally in ctx
+                // Only last row of logit matrix is needed as it contains logits corresponding to last token of the prompt
+                val logits = LlamaCpp.getLogits(if (isFirstRun) contextTokens else intArrayOf(sampledToken)).last()
+
+                // Get top 2^bitsPerToken logits for last token of prompt (= height of Huffman tree)
+                val topLogits = getTopLogits(logits)
+
+                // Construct Huffman tree from top logits
+                val huffmanCoding = HuffmanCoding()
+                huffmanCoding.buildHuffmanTree(topLogits)
+                huffmanCoding.mergeHuffmanNodes()
+                val root = huffmanCoding.generateHuffmanCodes()
+
+                // Traverse Huffman tree based on bits of secret message to sample next token, therefore encoding information in it
+                var currentNode = root
+
+                // First nodes won't have a token as they were created during the merge step
+                while (currentNode.token == null) {
+                    // First condition is needed in case (length of cipher bits) % (bits per token) != 0
+                    // In last loop of outer while, inner while can cause i to exceed cipherBitString.length
+                    // Second condition is only checked if first condition is false, so IndexOutOfBoundsException can't happen
+                    if (i >= cipherBitString.length || cipherBitString[i] == '0') {
+                        // Asserting left and right child nodes to be not null is safe as Huffman tree isn't traversed further down than bitsPerToken levels
+                        currentNode = currentNode.left!!
+                    }
+                    else {
+                        currentNode = currentNode.right!!
+                    }
+
+                    // Every time a turn is made when traversing the Huffman tree, another bit is encoded
+                    i++
+                }
+
+                // Token containing the right bitsPerToken bits of information in its path is now found
+                sampledToken = currentNode.token!!
+
+                // Update flag
+                isFirstRun = false
+            }
+            // Greedy sampling to pick most likely token until last sentence is finished
+            else {
+                // llama.cpp greedy sampler is used for efficiency instead of manually sorting logits descending and picking the first one
+                // Input is only last sampled token similar to else case of getLogits input above, as greedy sampling only over gets called after Huffman sampling
+                sampledToken = LlamaCpp.sample(sampledToken)
+
+                // Update flag
+                isLastSentenceFinished = LlamaCpp.isEndOfSentence(sampledToken)
+            }
+
+            // Append last sampled token to cover text tokens
+            coverTextTokens += sampledToken
+        }
+
+        // Detokenize cover text tokens into cover text to return it
+        val coverText = LlamaCpp.detokenize(coverTextTokens)
 
         return coverText
     }

--- a/app/src/main/java/org/vonderheidt/hips/utils/Huffman.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Huffman.kt
@@ -41,6 +41,9 @@ object Huffman {
                 // Only last row of logit matrix is needed as it contains logits corresponding to last token of the prompt
                 val logits = LlamaCpp.getLogits(if (isFirstRun) contextTokens else intArrayOf(sampledToken)).last()
 
+                // Suppress special tokens to avoid early termination before all bits of secret message are encoded
+                LlamaCpp.suppressSpecialTokens(logits)
+
                 // Get top 2^bitsPerToken logits for last token of prompt (= height of Huffman tree)
                 val topLogits = getTopLogits(logits)
 
@@ -123,6 +126,9 @@ object Huffman {
         while (i < coverTextTokens.size) {
             // Calculate the logit matrix again initially from context tokens, then from last cover text token, and get last row
             val logits = LlamaCpp.getLogits(if (isFirstRun) contextTokens else intArrayOf(coverTextToken)).last()
+
+            // Suppress special tokens
+            LlamaCpp.suppressSpecialTokens(logits)
 
             // Get top 2^bitsPerToken logits
             val topLogits = getTopLogits(logits)

--- a/app/src/main/java/org/vonderheidt/hips/utils/Huffman.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Huffman.kt
@@ -1,0 +1,39 @@
+package org.vonderheidt.hips.utils
+
+import kotlinx.coroutines.delay
+import org.vonderheidt.hips.data.Settings
+
+/**
+ * Object (i.e. singleton class) that represents steganography using Huffman encoding.
+ */
+object Huffman {
+    /**
+     * Function to encode (the encrypted binary representation of) the secret message into a cover text using Huffman encoding.
+     *
+     * Corresponds to Stegasuras method `encode_huffman` in `huffman_baseline.py`.
+     */
+    suspend fun encode(context: String, cipherBits: ByteArray, bitsPerToken: Int = Settings.bitsPerToken): String {
+        // Wait 5 seconds
+        delay(5000)
+
+        // Return placeholder
+        val coverText = ""
+
+        return coverText
+    }
+
+    /**
+     * Function to decode a cover text into (the encrypted binary representation of) the secret message using Huffman decoding.
+     *
+     * Corresponds to Stegasuras method `decode_huffman` in `huffman_baseline.py`.
+     */
+    suspend fun decode(context: String, coverText: String, bitsPerToken: Int = Settings.bitsPerToken): ByteArray {
+        // Wait 5 seconds
+        delay(5000)
+
+        // Return placeholder
+        val cipherBits = ByteArray(size = 0)
+
+        return cipherBits
+    }
+}

--- a/app/src/main/java/org/vonderheidt/hips/utils/HuffmanCoding.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/HuffmanCoding.kt
@@ -1,0 +1,101 @@
+package org.vonderheidt.hips.utils
+
+import java.util.PriorityQueue
+
+/**
+ * Class that represents the Huffman coding of a set of token IDs based on their logits.
+ *
+ * Corresponds to Stegasuras class `HuffmanCoding` and its method `__init__` in `huffman.py`. Attribute `heap` was renamed to `huffmanTree`, `codes` to `huffmanCodes`. `reverse_mapping` was dropped.
+ *
+ * @param huffmanTree A Huffman tree. Initialized as an empty Java PriorityQueue by default.
+ * @param huffmanCodes Mapping of token IDs to the corresponding Huffman codes. Initialized as an empty map by default.
+ */
+class HuffmanCoding(
+    private var huffmanTree: PriorityQueue<HuffmanNode> = PriorityQueue(),
+    var huffmanCodes: MutableMap<Int, String> = mutableMapOf()
+) {
+    /**
+     * Function to build the Huffman tree, given a map of token IDs and their logits.
+     *
+     * Corresponds to Stegasuras method `make_heap` of class `HuffmanCoding` in `huffman.py`. Parameter `frequency` was renamed to `tokenLogits`.
+     *
+     * @param tokenLogits Map of token IDs and their logits.
+     */
+    fun buildHuffmanTree(tokenLogits: Map<Int, Float>) {
+        // Loop through the map
+        for ((token, logit) in tokenLogits) {
+            // Create a new node for every entry
+            val huffmanNode = HuffmanNode(token, logit)
+
+            // Insert it into the Huffman tree
+            huffmanTree.offer(huffmanNode)
+        }
+    }
+
+    /**
+     * Function to merge all nodes in a Huffman tree.
+     *
+     * Corresponds to Stegasuras method `merge_nodes` of class `HuffmanCoding` in `huffman.py`.
+     */
+    fun mergeHuffmanNodes() {
+        // Run merge until only 1 node is left
+        while (huffmanTree.size > 1) {
+            // Poll two nodes from the Huffman tree
+            val left = huffmanTree.poll()
+            val right = huffmanTree.poll()
+
+            // Create a new parent node for them, combining their logits
+            val mergedHuffmanNode = HuffmanNode(null, left!!.logit + right!!.logit, left, right)
+
+            // Insert the new node into the Huffman tree
+            huffmanTree.offer(mergedHuffmanNode)
+        }
+    }
+
+    /**
+     * Function to generate Huffman codes on a given Huffman tree.
+     *
+     * Corresponds to Stegasuras method `make_codes` of class `HuffmanCoding` in `huffman.py`.
+     *
+     * @return Root node of the Huffman tree.
+     */
+    fun generateHuffmanCodes(): HuffmanNode {
+        // Poll the Huffman tree once to get the root node
+        val root = huffmanTree.poll()
+
+        // Initialize Huffman codes as an empty string
+        val currentHuffmanCode = ""
+
+        // Call helper function to traverse Huffman tree and store Huffman code for every node
+        generateHuffmanCodesRecursively(root, currentHuffmanCode)
+
+        // Return the root node polled above
+        return root!!
+    }
+
+    /**
+     * Helper function for generateHuffmanCodes. Traverses the Huffman tree recursively and stores the Huffman code for every node.
+     *
+     * Corresponds to Stegasuras method `make_codes_helper` of class `HuffmanCoding` in `huffman.py`. Parameter `root` was renamed to `currentHuffmanNode`, `current_code` to `currentHuffmanCode`.
+     *
+     * @param currentHuffmanNode Initially, root node of the Huffman tree. In recursive calls, left and right child nodes of itself.
+     * @param currentHuffmanCode Huffman code of the current Huffman node.
+     */
+    private fun generateHuffmanCodesRecursively(currentHuffmanNode: HuffmanNode?, currentHuffmanCode: String) {
+        // If the current node doesn't exist, there is nothing to do (i.e. recursion ends at the bottom of the Huffman tree)
+        if (currentHuffmanNode == null) {
+            return
+        }
+
+        // If the current node exists and has a token (i.e. is not one of the nodes inserted during merging), set its Huffman code to the current Huffman code
+        if (currentHuffmanNode.token != null) {
+            huffmanCodes[currentHuffmanNode.token] = currentHuffmanCode
+
+            return
+        }
+
+        // Traverse left and right subtrees of the current node, appending 0 or 1 respectively to set Huffman codes there
+        generateHuffmanCodesRecursively(currentHuffmanNode.left, currentHuffmanCode + "0")
+        generateHuffmanCodesRecursively(currentHuffmanNode.right, currentHuffmanCode + "1")
+    }
+}

--- a/app/src/main/java/org/vonderheidt/hips/utils/HuffmanNode.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/HuffmanNode.kt
@@ -1,0 +1,32 @@
+package org.vonderheidt.hips.utils
+
+/**
+ * Class that represents a node in a Huffman tree. Implements the Kotlin Comparable interface as the Huffman tree is a Java PriorityQueue.
+ *
+ * Corresponds to Stegasuras class `HeapNode` and its method `__init__` in `huffman.py`. Attribute `freq` (frequency) was renamed to `logit` to match attribute `token`.
+ *
+ * @param token Token ID.
+ * @param logit Token logit.
+ * @param left Left child node.
+ * @param right Right child node.
+ */
+class HuffmanNode(
+    val token: Int?,
+    val logit: Float,
+    val left: HuffmanNode? = null,
+    val right: HuffmanNode? = null
+) : Comparable<HuffmanNode> {
+    /**
+     * Function to compare nodes in a Huffman tree with each other based on their logits.
+     *
+     * Corresponds to Stegasuras methods `__lt__` and `__eq__` of class `HeapNode` in `huffman.py`.
+     *
+     * @param other Node to be compared to `this` node.
+     * @return -1, 0 or 1 depending on whether `this.logit` is <, == or > `other.logit`.
+     */
+    override fun compareTo(other: HuffmanNode): Int {
+        // Doesn't strictly have to return -1, 0 or 1
+        // Negative value corresponds to <, zero corresponds to ==, positive value corresponds to >
+        return this.logit.compareTo(other.logit)
+    }
+}

--- a/app/src/main/java/org/vonderheidt/hips/utils/LLM.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LLM.kt
@@ -11,8 +11,8 @@ import java.io.File
  * Object (i.e. singleton class) to handle LLM download.
  */
 object LLM {
-    private const val DOWNLOAD_LINK = "https://upload.wikimedia.org/wikipedia/commons/9/9a/Pablo_Escobar_Mug.jpg?download"
-    private const val FILE_NAME = "Pablo_Escobar_Mug.jpg"
+    private const val DOWNLOAD_LINK = "https://huggingface.co/hugging-quants/Llama-3.2-1B-Instruct-Q4_K_M-GGUF/resolve/main/llama-3.2-1b-instruct-q4_k_m.gguf"
+    private const val FILE_NAME = "llama-3.2-1b-instruct-q4_k_m.gguf"
 
     /**
      * Function to check if the LLM has already been downloaded.

--- a/app/src/main/java/org/vonderheidt/hips/utils/LLM.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LLM.kt
@@ -7,43 +7,48 @@ import android.os.Environment
 import android.widget.Toast
 import java.io.File
 
-const val DOWNLOAD_LINK = "https://upload.wikimedia.org/wikipedia/commons/9/9a/Pablo_Escobar_Mug.jpg?download"
-const val FILE_NAME = "Pablo_Escobar_Mug.jpg"
-
 /**
- * Function to check if the LLM has already been downloaded.
+ * Object (i.e. singleton class) to handle LLM download.
  */
-fun llmDownloaded(): Boolean {
-    val downloadDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
-    val file = File(downloadDir, FILE_NAME)
+object LLM {
+    private const val DOWNLOAD_LINK = "https://upload.wikimedia.org/wikipedia/commons/9/9a/Pablo_Escobar_Mug.jpg?download"
+    private const val FILE_NAME = "Pablo_Escobar_Mug.jpg"
 
-    return file.exists()
-}
+    /**
+     * Function to check if the LLM has already been downloaded.
+     */
+    fun isDownloaded(): Boolean {
+        val downloadDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+        val file = File(downloadDir, FILE_NAME)
 
-/**
- * Function to download the LLM.
- */
-fun downloadLLM(currentLocalContext: Context) {
-    // Get access to Android's download manager
-    val downloadManager = currentLocalContext.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
-
-    // Define request to the download manager that downloads the file from the given URL
-    val request = DownloadManager.Request(Uri.parse(DOWNLOAD_LINK))
-        .setTitle(FILE_NAME)
-        .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, FILE_NAME)
-        .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
-
-    // Queue request and save download ID
-    // Will even wait for an internet connection to become available, i.e. being offline doesn't cause an error as caught below
-    val downloadId: Long = downloadManager.enqueue(request)
-
-    // Check for errors
-    if (downloadId != -1L) {
-        // Show confirmation via toast message
-        Toast.makeText(currentLocalContext, "Download started", Toast.LENGTH_LONG).show()
+        return file.exists()
     }
-    else {
-        // Show error via toast message
-        Toast.makeText(currentLocalContext, "Download failed", Toast.LENGTH_LONG).show()
+
+    /**
+     * Function to download the LLM.
+     */
+    fun download(currentLocalContext: Context) {
+        // Get access to Android's download manager
+        val downloadManager = currentLocalContext.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+
+        // Define request to the download manager that downloads the file from the given URL
+        val request = DownloadManager.Request(Uri.parse(DOWNLOAD_LINK))
+            .setTitle(FILE_NAME)
+            .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, FILE_NAME)
+            .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+
+        // Queue request and save download ID
+        // Will even wait for an internet connection to become available, i.e. being offline doesn't cause an error as caught below
+        val downloadId: Long = downloadManager.enqueue(request)
+
+        // Check for errors
+        if (downloadId != -1L) {
+            // Show confirmation via toast message
+            Toast.makeText(currentLocalContext, "Download started", Toast.LENGTH_LONG).show()
+        }
+        else {
+            // Show error via toast message
+            Toast.makeText(currentLocalContext, "Download failed", Toast.LENGTH_LONG).show()
+        }
     }
 }

--- a/app/src/main/java/org/vonderheidt/hips/utils/LLM.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LLM.kt
@@ -51,4 +51,14 @@ object LLM {
             Toast.makeText(currentLocalContext, "Download failed", Toast.LENGTH_LONG).show()
         }
     }
+
+    /**
+     * Function to get the path to the LLM (.gguf file).
+     */
+    fun getPath(): String {
+        val downloadDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+        val path = "$downloadDir/$FILE_NAME"
+
+        return path
+    }
 }

--- a/app/src/main/java/org/vonderheidt/hips/utils/LLM.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LLM.kt
@@ -1,18 +1,21 @@
 package org.vonderheidt.hips.utils
 
+import android.app.DownloadManager
+import android.content.Context
+import android.net.Uri
 import android.os.Environment
-import kotlinx.coroutines.delay
+import android.widget.Toast
 import java.io.File
+
+const val DOWNLOAD_LINK = "https://upload.wikimedia.org/wikipedia/commons/9/9a/Pablo_Escobar_Mug.jpg?download"
+const val FILE_NAME = "Pablo_Escobar_Mug.jpg"
 
 /**
  * Function to check if the LLM has already been downloaded.
  */
 fun llmDownloaded(): Boolean {
-    // Let the LLM be called "llm.gguf"
     val downloadDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
-    val fileName = "llm.gguf"
-
-    val file = File(downloadDir, fileName)
+    val file = File(downloadDir, FILE_NAME)
 
     return file.exists()
 }
@@ -20,7 +23,27 @@ fun llmDownloaded(): Boolean {
 /**
  * Function to download the LLM.
  */
-suspend fun downloadLLM() {
-    // Wait 5 seconds
-    delay(5000)
+fun downloadLLM(currentLocalContext: Context) {
+    // Get access to Android's download manager
+    val downloadManager = currentLocalContext.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+
+    // Define request to the download manager that downloads the file from the given URL
+    val request = DownloadManager.Request(Uri.parse(DOWNLOAD_LINK))
+        .setTitle(FILE_NAME)
+        .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, FILE_NAME)
+        .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+
+    // Queue request and save download ID
+    // Will even wait for an internet connection to become available, i.e. being offline doesn't cause an error as caught below
+    val downloadId: Long = downloadManager.enqueue(request)
+
+    // Check for errors
+    if (downloadId != -1L) {
+        // Show confirmation via toast message
+        Toast.makeText(currentLocalContext, "Download started", Toast.LENGTH_LONG).show()
+    }
+    else {
+        // Show error via toast message
+        Toast.makeText(currentLocalContext, "Download failed", Toast.LENGTH_LONG).show()
+    }
 }

--- a/app/src/main/java/org/vonderheidt/hips/utils/LLM.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LLM.kt
@@ -1,13 +1,20 @@
 package org.vonderheidt.hips.utils
 
+import android.os.Environment
 import kotlinx.coroutines.delay
+import java.io.File
 
 /**
  * Function to check if the LLM has already been downloaded.
  */
 fun llmDownloaded(): Boolean {
-    // Initially, LLM hasn't been downloaded yet
-    return false
+    // Let the LLM be called "llm.gguf"
+    val downloadDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+    val fileName = "llm.gguf"
+
+    val file = File(downloadDir, fileName)
+
+    return file.exists()
 }
 
 /**

--- a/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
@@ -55,7 +55,7 @@ object LlamaCpp {
 
         synchronized(this) {
             if (isInMemory()) {
-                // Unload ctx first as model is needed for ctx
+                // Unload context first as LLM is needed for context
                 unloadCtx()
                 ctx = 0L
 

--- a/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
@@ -7,7 +7,7 @@ object LlamaCpp {
     private val path = LLM.getPath()
 
     // Annotate pointers to the LLM, its context and sampler as volatile so that r/w to them is atomic and immediately visible to all threads
-    // Avoids race conditions, i.e. multiple threads trying to load/unload the LLM or its context simultaneously
+    // Avoids race conditions, i.e. multiple threads trying to load/unload the LLM, its context or sampler simultaneously
     @Volatile
     private var model = 0L
 
@@ -40,7 +40,7 @@ object LlamaCpp {
         }
 
         // Otherwise, load the LLM and store its memory address
-        // Synchronized allows only one thread to execute the code inside {...}, so other threads can't load LLM simultaneously
+        // Synchronized allows only one thread to execute the code inside {...}, so other threads can't load the LLM simultaneously
         synchronized(this) {
             if (!isInMemory()) {
                 model = loadModel()

--- a/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
@@ -107,4 +107,13 @@ object LlamaCpp {
      * @return Tokenization as an array of token IDs.
      */
     external fun tokenize(string: String, ctx: Long = this.ctx): IntArray
+
+    /**
+     * Wrapper for the `common_detokenize` function of llama.cpp. Detokenizes an array of token IDs into a string.
+     *
+     * @param tokens Array of token IDs.
+     * @param ctx Memory address of the context.
+     * @return Detokenization as a string.
+     */
+    external fun detokenize(tokens: IntArray, ctx: Long = this.ctx): String
 }

--- a/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
@@ -181,4 +181,13 @@ object LlamaCpp {
      * @return Detokenization as a string.
      */
     external fun detokenize(tokens: IntArray, ctx: Long = this.ctx): String
+
+    /**
+     * Wrapper for the `llama_sampler_sample` function of llama.cpp. Samples the next token based on the last one.
+     *
+     * @param lastToken ID of the last token.
+     * @param ctx Memory address of the context.
+     * @return ID of the next token.
+     */
+    external fun sample(lastToken: Int, ctx: Long = this.ctx, smpl: Long = this.smpl): Int
 }

--- a/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
@@ -74,6 +74,25 @@ object LlamaCpp {
         }
     }
 
+    /**
+     * Function to check if a token is the end of a sentence. Needed to complete the last sentence of the cover text.
+     *
+     * Corresponds to Stegasuras method `is_sent_finish` in `utils.py`.
+     *
+     * @param token Token ID to check.
+     * @return Boolean that is true if the token ends with `.`, `?` or `!`, false otherwise.
+     */
+    fun isEndOfSentence(token: Int): Boolean {
+        // Detokenize the token and check if it ends with a punctuation mark (covers "?" vs " ?" etc)
+        val detokenization = detokenize(intArrayOf(token))
+
+        val isSentenceFinished = detokenization.endsWith(".")
+                || detokenization.endsWith("!")
+                || detokenization.endsWith("?")
+
+        return isSentenceFinished
+    }
+
     // Declare the native methods called via JNI as Kotlin external functions
 
     /**

--- a/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
@@ -96,4 +96,15 @@ object LlamaCpp {
      * @param ctx Memory address of the context.
      */
     private external fun unloadCtx(ctx: Long = this.ctx)
+
+    // Parameter ctx is optional since it has a default value, put it at the end to avoid conflicts
+
+    /**
+     * Wrapper for the `common_tokenize` function of llama.cpp. Tokenizes a string into an array of token IDs.
+     *
+     * @param string String to be tokenized.
+     * @param ctx Memory address of the context.
+     * @return Tokenization as an array of token IDs.
+     */
+    external fun tokenize(string: String, ctx: Long = this.ctx): IntArray
 }

--- a/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
@@ -183,6 +183,17 @@ object LlamaCpp {
     external fun detokenize(tokens: IntArray, ctx: Long = this.ctx): String
 
     /**
+     * Wrapper for the `llama_get_logits` function of llama.cpp. Calculates the logit matrix (i.e. predictions for every token in the prompt).
+     *
+     * Only the last row of the `n_tokens` x `n_vocab` matrix is actually needed as it contains the logits corresponding to the last token of the prompt.
+     *
+     * @param tokens Token IDs from tokenization of the prompt.
+     * @param ctx Memory address of the context.
+     * @return The logit matrix.
+     */
+    external fun getLogits(tokens: IntArray, ctx: Long = this.ctx): Array<FloatArray>
+
+    /**
      * Wrapper for the `llama_sampler_sample` function of llama.cpp. Samples the next token based on the last one.
      *
      * @param lastToken ID of the last token.

--- a/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
@@ -168,7 +168,7 @@ object LlamaCpp {
     /**
      * Wrapper for the `llama_sampler_init_*` functions of llama.cpp. Loads the sampler into memory.
      *
-     * Currently only supports greedy sampler for Huffman encoding.
+     * Currently only supports greedy sampler.
      *
      * @return Memory address of the sampler.
      */

--- a/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
@@ -13,4 +13,11 @@ object LlamaCpp {
      * @return Memory address of the LLM.
      */
     external fun loadModel(path: String = this.path): Long
+
+    /**
+     * Wrapper for the `llama_free_model` function of llama.cpp. Unloads the LLM from memory.
+     *
+     * @param model Memory address of the LLM.
+     */
+    external fun unloadModel(model: Long)
 }

--- a/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
@@ -75,6 +75,27 @@ object LlamaCpp {
     }
 
     /**
+     * Function to reset the instance of the LLM in a thread-safe manner.
+     *
+     * Needed to ensure reproducible results when switching between encode/decode mode or when encoding/decoding multiple times sequentially.
+     */
+    fun resetInstance() {
+        // Mirrors startInstance
+        if (ctx == 0L) {
+            return
+        }
+
+        synchronized(this) {
+            if (ctx != 0L) {
+                unloadCtx()
+                ctx = 0L
+
+                ctx = loadCtx()
+            }
+        }
+    }
+
+    /**
      * Function to check if a token is the end of a sentence. Needed to complete the last sentence of the cover text.
      *
      * Corresponds to Stegasuras method `is_sent_finish` in `utils.py`.

--- a/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
@@ -96,6 +96,25 @@ object LlamaCpp {
     }
 
     /**
+     * Function to suppress special tokens, i.e. eog (end-of-generation) and control tokens.
+     *
+     * Suppressing eog tokens is needed to avoid early termination when generating a cover text.
+     *
+     * Additionally suppressing control tokens is beneficial because the cover text then can't contain any invisible tokens.
+     * This ensures integrity when using a non-digital communication medium.
+     *
+     * @param logits Logits for the last token of the prompt (= last row of logits matrix).
+     */
+    fun suppressSpecialTokens(logits: FloatArray) {
+        // Suppress special tokens by setting their logits to negative values
+        for (token in logits.indices) {
+            if (isSpecial(token)) {
+                logits[token] = -100f
+            }
+        }
+    }
+
+    /**
      * Function to check if a token is the end of a sentence. Needed to complete the last sentence of the cover text.
      *
      * Corresponds to Stegasuras method `is_sent_finish` in `utils.py`.
@@ -192,6 +211,15 @@ object LlamaCpp {
      * @return The logit matrix.
      */
     external fun getLogits(tokens: IntArray, ctx: Long = this.ctx): Array<FloatArray>
+
+    /**
+     * Wrapper for the `llama_token_is_eog` and `llama_token_is_control` functions of llama.cpp. Checks if a token is a special token.
+     *
+     * @param token Token ID to check.
+     * @param ctx Memory address of the context.
+     * @return Boolean that is true if the token special, false otherwise.
+     */
+    private external fun isSpecial(token: Int, ctx: Long = this.ctx): Boolean
 
     /**
      * Wrapper for the `llama_sampler_sample` function of llama.cpp. Samples the next token based on the last one.

--- a/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
@@ -1,0 +1,16 @@
+package org.vonderheidt.hips.utils
+
+/**
+ * Object (i.e. singleton class) to declare Kotlin external functions corresponding to llama.cpp functions.
+ */
+object LlamaCpp {
+    private val path = LLM.getPath()
+
+    /**
+     * Wrapper for the `llama_load_model_from_file` function of llama.cpp. Loads the LLM into memory.
+     *
+     * @param path Path to the LLM (.gguf file).
+     * @return Memory address of the LLM.
+     */
+    external fun loadModel(path: String = this.path): Long
+}

--- a/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
@@ -117,7 +117,7 @@ object LlamaCpp {
     // Declare the native methods called via JNI as Kotlin external functions
 
     /**
-     * Wrapper for the `llama_load_model_from_file` function of llama.cpp. Loads the LLM into memory.
+     * Wrapper for the `llama_model_load_from_file` function of llama.cpp. Loads the LLM into memory.
      *
      * @param path Path to the LLM (.gguf file).
      * @return Memory address of the LLM.
@@ -125,7 +125,7 @@ object LlamaCpp {
     private external fun loadModel(path: String = this.path): Long
 
     /**
-     * Wrapper for the `llama_free_model` function of llama.cpp. Unloads the LLM from memory.
+     * Wrapper for the `llama_model_free` function of llama.cpp. Unloads the LLM from memory.
      *
      * @param model Memory address of the LLM.
      */

--- a/app/src/main/java/org/vonderheidt/hips/utils/Steganography.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Steganography.kt
@@ -8,6 +8,12 @@ import org.vonderheidt.hips.data.Settings
 object Steganography {
     /**
      * Function to encode secret message into cover text using given context.
+     *
+     * @param context The context to encode the secret message with.
+     * @param secretMessage The secret message to be encoded.
+     * @param conversionMode Conversion mode, determined by Settings object.
+     * @param steganographyMode Steganography mode, determined by Settings object.
+     * @return A cover text containing the secret message.
      */
     suspend fun encode(
         context: String,
@@ -39,6 +45,12 @@ object Steganography {
 
     /**
      * Function to decode secret message from cover text using given context.
+     *
+     * @param context The context to decode the cover text with.
+     * @param coverText The cover text containing a secret message.
+     * @param conversionMode Conversion mode, determined by Settings object.
+     * @param steganographyMode Steganography mode, determined by Settings object.
+     * @return The secret message.
      */
     suspend fun decode(
         context: String,

--- a/app/src/main/java/org/vonderheidt/hips/utils/Steganography.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Steganography.kt
@@ -3,23 +3,28 @@ package org.vonderheidt.hips.utils
 import kotlinx.coroutines.delay
 
 /**
- * Function to encode secret message into cover text using given context.
+ * Object (i.e. singleton class) that represents steganography encoding and decoding.
  */
-suspend fun encode(context: String, secretMessage: String): String {
-    // Wait 5 seconds
-    delay(5000)
+object Steganography {
+    /**
+     * Function to encode secret message into cover text using given context.
+     */
+    suspend fun encode(context: String, secretMessage: String): String {
+        // Wait 5 seconds
+        delay(5000)
 
-    // Return placeholder string
-    return "Encode of $secretMessage using $context"
-}
+        // Return placeholder string
+        return "Encode of $secretMessage using $context"
+    }
 
-/**
- * Function to decode secret message from cover text using given context.
- */
-suspend fun decode(context: String, coverText: String): String {
-    // Wait 5 seconds
-    delay(5000)
+    /**
+     * Function to decode secret message from cover text using given context.
+    */
+    suspend fun decode(context: String, coverText: String): String {
+        // Wait 5 seconds
+        delay(5000)
 
-    // Return placeholder string
-    return "Decode of $coverText using $context"
+        // Return placeholder string
+        return "Decode of $coverText using $context"
+    }
 }

--- a/app/src/main/java/org/vonderheidt/hips/utils/Steganography.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Steganography.kt
@@ -1,6 +1,6 @@
 package org.vonderheidt.hips.utils
 
-import kotlinx.coroutines.delay
+import org.vonderheidt.hips.data.Settings
 
 /**
  * Object (i.e. singleton class) that represents steganography encoding and decoding.
@@ -9,22 +9,56 @@ object Steganography {
     /**
      * Function to encode secret message into cover text using given context.
      */
-    suspend fun encode(context: String, secretMessage: String): String {
-        // Wait 5 seconds
-        delay(5000)
+    suspend fun encode(
+        context: String,
+        secretMessage: String,
+        conversionMode: ConversionMode = Settings.conversionMode,
+        steganographyMode: SteganographyMode = Settings.steganographyMode
+    ): String {
+        // Step 1: Convert secret message to a (compressed) binary representation
+        val plainBits = when (conversionMode) {
+            ConversionMode.Arithmetic -> { Arithmetic.decode("", secretMessage) }   // Stegasuras: Arithmetic binary conversion is just decoding with empty context
+            ConversionMode.UTF8 -> { UTF8.encode(secretMessage) }
+        }
 
-        // Return placeholder string
-        return "Encode of $secretMessage using $context"
+        // Step 2: Encrypt binary representation of secret message
+        val cipherBits = Crypto.encrypt(plainBits)
+
+        // Step 3: Encode encrypted binary representation of secret message into cover text
+        val coverText = when (steganographyMode) {
+            SteganographyMode.Arithmetic -> { Arithmetic.encode(context, cipherBits) }
+            SteganographyMode.Bins -> { Bins.encode(context, cipherBits) }
+            SteganographyMode.Huffman -> { Huffman.encode(context, cipherBits) }
+        }
+
+        return coverText
     }
 
     /**
      * Function to decode secret message from cover text using given context.
-    */
-    suspend fun decode(context: String, coverText: String): String {
-        // Wait 5 seconds
-        delay(5000)
+     */
+    suspend fun decode(
+        context: String,
+        coverText: String,
+        conversionMode: ConversionMode = Settings.conversionMode,
+        steganographyMode: SteganographyMode = Settings.steganographyMode
+    ): String {
+        // Invert step 3
+        val cipherBits = when (steganographyMode) {
+            SteganographyMode.Arithmetic -> { Arithmetic.decode(context, coverText) }
+            SteganographyMode.Bins -> { Bins.decode(context, coverText) }
+            SteganographyMode.Huffman -> { Huffman.decode(context, coverText) }
+        }
 
-        // Return placeholder string
-        return "Decode of $coverText using $context"
+        // Invert step 2
+        val plainBits = Crypto.decrypt(cipherBits)
+
+        // Invert step 1
+        val secretMessage = when (conversionMode) {
+            ConversionMode.Arithmetic -> { Arithmetic.encode("", plainBits) }   // Stegasuras: Arithmetic string conversion is just encoding with empty context
+            ConversionMode.UTF8 -> { UTF8.decode(plainBits) }
+        }
+
+        return secretMessage
     }
 }

--- a/app/src/main/java/org/vonderheidt/hips/utils/Steganography.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Steganography.kt
@@ -15,10 +15,13 @@ object Steganography {
         conversionMode: ConversionMode = Settings.conversionMode,
         steganographyMode: SteganographyMode = Settings.steganographyMode
     ): String {
+        // Step 0: Prepare secret message by appending ASCII NUL character
+        val preparedSecretMessage = prepare(secretMessage)
+
         // Step 1: Convert secret message to a (compressed) binary representation
         val plainBits = when (conversionMode) {
-            ConversionMode.Arithmetic -> { Arithmetic.decode("", secretMessage) }   // Stegasuras: Arithmetic binary conversion is just decoding with empty context
-            ConversionMode.UTF8 -> { UTF8.encode(secretMessage) }
+            ConversionMode.Arithmetic -> { Arithmetic.decode("", preparedSecretMessage) }   // Stegasuras: Arithmetic binary conversion is just decoding with empty context
+            ConversionMode.UTF8 -> { UTF8.encode(preparedSecretMessage) }
         }
 
         // Step 2: Encrypt binary representation of secret message
@@ -54,10 +57,45 @@ object Steganography {
         val plainBits = Crypto.decrypt(cipherBits)
 
         // Invert step 1
-        val secretMessage = when (conversionMode) {
+        val preparedSecretMessage = when (conversionMode) {
             ConversionMode.Arithmetic -> { Arithmetic.encode("", plainBits) }   // Stegasuras: Arithmetic string conversion is just encoding with empty context
             ConversionMode.UTF8 -> { UTF8.decode(plainBits) }
         }
+
+        // Invert step 0
+        val secretMessage = unprepare(preparedSecretMessage)
+
+        return secretMessage
+    }
+
+    /**
+     * Function to prepare a secret message for binary encoding.
+     *
+     * Appends the ASCII NUL character to the original secret message. Needed to remove artefacts from greedy sampling after binary decoding.
+     *
+     * @param secretMessage A secret message.
+     * @return The prepared secret message.
+     */
+    private fun prepare(secretMessage: String): String {
+        // Kotlin doesn't use NUL-terminated strings, instead makes them immutable and stores length
+        // So using NUL as a character in a Kotlin string can't cause any collisions
+        val preparedSecretMessage = secretMessage + '\u0000'
+
+        return preparedSecretMessage
+    }
+
+    /**
+     * Function to unprepare a secret message after binary decoding.
+     *
+     * Strips the ASCII NUL character and everything after it. Therefore removes any artefacts from greedy sampling, rendering the original secret message.
+     *
+     * @param preparedSecretMessage A prepared secret message.
+     * @return The secret message.
+     */
+    private fun unprepare(preparedSecretMessage: String): String {
+        val secretMessage = preparedSecretMessage
+            .split('\u0000')
+            .first()
 
         return secretMessage
     }

--- a/app/src/main/java/org/vonderheidt/hips/utils/SteganographyMode.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/SteganographyMode.kt
@@ -1,0 +1,21 @@
+package org.vonderheidt.hips.utils
+
+/**
+ * Class to enumerate all steganography modes.
+ *
+ * @param displayName Display name of the steganography mode.
+ */
+enum class SteganographyMode(private val displayName: String) {
+    Arithmetic("Arithmetic (recommended)"),
+    Bins("Bins"),
+    Huffman("Huffman");
+
+    /**
+     * Function to get the display name of the steganography mode.
+     *
+     * @return Display name of the steganography mode.
+     */
+    override fun toString(): String {
+        return displayName
+    }
+}

--- a/app/src/main/java/org/vonderheidt/hips/utils/UTF8.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/UTF8.kt
@@ -1,7 +1,5 @@
 package org.vonderheidt.hips.utils
 
-import kotlinx.coroutines.delay
-
 /**
  * Object (i.e. singleton class) that represents the binary conversion of the secret message using UTF-8 encoding.
  *
@@ -14,12 +12,8 @@ object UTF8 {
      * @param secretMessage Secret message.
      * @return Binary representation of the secret message.
      */
-    suspend fun encode(secretMessage: String): ByteArray {
-        // Wait 5 seconds
-        delay(5000)
-
-        // Return placeholder
-        val plainBits = ByteArray(size = 0)
+    fun encode(secretMessage: String): ByteArray {
+        val plainBits = secretMessage.toByteArray(charset = Charsets.UTF_8)
 
         return plainBits
     }
@@ -30,13 +24,9 @@ object UTF8 {
      * @param plainBits Binary representation of the secret message.
      * @return Secret message.
      */
-    suspend fun decode(plainBits: ByteArray): String {
-        // Wait 5 seconds
-        delay(5000)
+    fun decode(plainBits: ByteArray): String {
+        val secretMessage = String(bytes = plainBits, charset = Charsets.UTF_8)
 
-        // Return placeholder
-        val coverText = ""
-
-        return coverText
+        return secretMessage
     }
 }

--- a/app/src/main/java/org/vonderheidt/hips/utils/UTF8.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/UTF8.kt
@@ -9,11 +9,11 @@ object UTF8 {
     /**
      * Function to convert a string into its binary representation using UTF-8 encoding.
      *
-     * @param secretMessage Secret message.
-     * @return Binary representation of the secret message.
+     * @param preparedSecretMessage A prepared secret message.
+     * @return The binary representation of the prepared secret message.
      */
-    fun encode(secretMessage: String): ByteArray {
-        val plainBits = secretMessage.toByteArray(charset = Charsets.UTF_8)
+    fun encode(preparedSecretMessage: String): ByteArray {
+        val plainBits = (preparedSecretMessage).toByteArray(charset = Charsets.UTF_8)
 
         return plainBits
     }
@@ -21,12 +21,12 @@ object UTF8 {
     /**
      * Function to convert the binary representation of a string back to the string using UTF-8 decoding.
      *
-     * @param plainBits Binary representation of the secret message.
-     * @return Secret message.
+     * @param plainBits The binary representation of a prepared secret message.
+     * @return The prepared secret message.
      */
     fun decode(plainBits: ByteArray): String {
-        val secretMessage = String(bytes = plainBits, charset = Charsets.UTF_8)
+        val preparedSecretMessage = String(bytes = plainBits, charset = Charsets.UTF_8)
 
-        return secretMessage
+        return preparedSecretMessage
     }
 }

--- a/app/src/main/java/org/vonderheidt/hips/utils/UTF8.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/UTF8.kt
@@ -1,0 +1,42 @@
+package org.vonderheidt.hips.utils
+
+import kotlinx.coroutines.delay
+
+/**
+ * Object (i.e. singleton class) that represents the binary conversion of the secret message using UTF-8 encoding.
+ *
+ * Renamed from `Unicode` in Stegasuras as UTF-8 is only one of many possible Unicode encodings.
+ */
+object UTF8 {
+    /**
+     * Function to convert a string into its binary representation using UTF-8 encoding.
+     *
+     * @param secretMessage Secret message.
+     * @return Binary representation of the secret message.
+     */
+    suspend fun encode(secretMessage: String): ByteArray {
+        // Wait 5 seconds
+        delay(5000)
+
+        // Return placeholder
+        val plainBits = ByteArray(size = 0)
+
+        return plainBits
+    }
+
+    /**
+     * Function to convert the binary representation of a string back to the string using UTF-8 decoding.
+     *
+     * @param plainBits Binary representation of the secret message.
+     * @return Secret message.
+     */
+    suspend fun decode(plainBits: ByteArray): String {
+        // Wait 5 seconds
+        delay(5000)
+
+        // Return placeholder
+        val coverText = ""
+
+        return coverText
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.7.3"
+agp = "8.8.0"
 kotlin = "2.0.0"
 coreKtx = "1.15.0"
 junit = "4.13.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.7.2"
+agp = "8.7.3"
 kotlin = "2.0.0"
 coreKtx = "1.15.0"
 junit = "4.13.2"
@@ -7,9 +7,9 @@ junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.9.3"
-composeBom = "2024.11.00"
-navigationCompose = "2.8.4"
-materialIconsExtended = "1.7.5"
+composeBom = "2024.12.01"
+navigationCompose = "2.8.5"
+materialIconsExtended = "1.7.6"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ activityCompose = "1.9.3"
 composeBom = "2024.12.01"
 navigationCompose = "2.8.5"
 materialIconsExtended = "1.7.6"
+datastorePreferences = "1.1.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -28,6 +29,7 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "materialIconsExtended" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Nov 08 22:14:20 CET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Implemented steganography via Huffman encoding:
- Added button to download LLM to settings screen
- Added [llama.cpp](https://github.com/ggerganov/llama.cpp) via CMake
- Added LlamaCpp Kotlin wrapper to manage state of LLM and provide various functions 
- Added button to load LLM into memory to settings screen
- Added algorithm selection to settings screen
- Added persistent saving of settings to DataStore
- Added UTF-8 binary conversion
- Added data structures for Huffman tree
- Added Huffman sampling for encoding the secret message into a cover text
- Added greedy sampling for finishing the last sentence of the cover text
- Solved problem of decoding the cover text without artefacts from greedy sampling
- Improved documentation
- Various minor cleanups

Open TODOs:
- `llama_get_logits` consistently returns `1` x `n_vocab` instead of `n_tokens` x `n_vocab` matrix, possibly related to use of `llama_batch_get_one`, but doesn't affect cover text quality