### PR TITLE
Implement steganography on conversation screen

### DIFF
--- a/app/src/main/cpp/hips.cpp
+++ b/app/src/main/cpp/hips.cpp
@@ -35,7 +35,7 @@
  * @param jPath Path to the LLM (.gguf file).
  * @return Memory address of the LLM.
  */
-extern "C" JNIEXPORT jlong JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_loadModel(JNIEnv* env, jobject thiz, jstring jPath) {
+extern "C" JNIEXPORT jlong JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_loadModel(JNIEnv* env, jobject /* thiz */, jstring jPath) {
     // Convert path to LLM from Java string to C++ string using the JNI environment
     // Set isCopy == true to copy Java string so it doesn't get overwritten in memory
     jboolean isCopy = true;
@@ -72,7 +72,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_load
  * @param thiz Java object this function was called with.
  * @param jModel Memory address of the LLM.
  */
-extern "C" JNIEXPORT void JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_unloadModel(JNIEnv* env, jobject thiz, jlong jModel) {
+extern "C" JNIEXPORT void JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_unloadModel(JNIEnv* /* env */, jobject /* thiz */, jlong jModel) {
     // Cast memory address of LLM from Java long to C++ pointer
     auto cppModel = reinterpret_cast<llama_model*>(jModel);
 
@@ -92,7 +92,7 @@ extern "C" JNIEXPORT void JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_unloa
  * @param jModel Memory address of the LLM.
  * @return Memory address of the context.
  */
-extern "C" JNIEXPORT jlong JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_loadCtx(JNIEnv* env, jobject thiz, jlong jModel) {
+extern "C" JNIEXPORT jlong JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_loadCtx(JNIEnv* /* env */, jobject /* thiz */, jlong jModel) {
     // Similar to loadModel
 
     // Cast memory address of the LLM from Java long to C++ pointer
@@ -125,7 +125,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_load
  * @param thiz Java object this function was called with.
  * @param jCtx Memory address of the context.
  */
-extern "C" JNIEXPORT void JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_unloadCtx(JNIEnv* env, jobject thiz, jlong jCtx) {
+extern "C" JNIEXPORT void JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_unloadCtx(JNIEnv* /* env */, jobject /* thiz */, jlong jCtx) {
     // Similar to unloadModel
 
     // Cast memory address of context from Java long to C++ pointer
@@ -147,7 +147,7 @@ extern "C" JNIEXPORT void JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_unloa
  * @param thiz Java object this function was called with.
  * @return Memory address of the sampler.
  */
-extern "C" JNIEXPORT jlong JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_loadSmpl(JNIEnv* env, jobject thiz) {
+extern "C" JNIEXPORT jlong JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_loadSmpl(JNIEnv* /* env */, jobject /* thiz */) {
     // Similar to loadModel
 
     // Initialize greedy sampler (no sampler chain needed when using only a single sampler)
@@ -174,7 +174,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_load
  * @param thiz Java object this function was called with.
  * @param jSmpl Memory address of the sampler.
  */
-extern "C" JNIEXPORT void JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_unloadSmpl(JNIEnv* env, jobject thiz, jlong jSmpl) {
+extern "C" JNIEXPORT void JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_unloadSmpl(JNIEnv* /* env */, jobject /* thiz */, jlong jSmpl) {
     // Similar to unloadModel
 
     // Cast memory address of sampler from Java long to C++ pointer
@@ -197,7 +197,7 @@ extern "C" JNIEXPORT void JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_unloa
  * @param jCtx Memory address of the context.
  * @return Tokenization as an array of token IDs.
  */
-extern "C" JNIEXPORT jintArray JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_tokenize(JNIEnv* env, jobject thiz, jstring jString, jlong jCtx) {
+extern "C" JNIEXPORT jintArray JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_tokenize(JNIEnv* env, jobject /* thiz */, jstring jString, jlong jCtx) {
     // Cast memory address of the context from Java long to C++ pointer
     auto cppCtx = reinterpret_cast<llama_context*>(jCtx);
 
@@ -231,7 +231,7 @@ extern "C" JNIEXPORT jintArray JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_
  * @param jCtx Memory address of the context.
  * @return Detokenization as a string.
  */
-extern "C" JNIEXPORT jstring JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_detokenize(JNIEnv* env, jobject thiz, jintArray jTokens, jlong jCtx) {
+extern "C" JNIEXPORT jstring JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_detokenize(JNIEnv* env, jobject /* thiz */, jintArray jTokens, jlong jCtx) {
     // Cast memory address of the context from Java long to C++ pointer
     auto cppCtx = reinterpret_cast<llama_context*>(jCtx);
 
@@ -261,7 +261,7 @@ extern "C" JNIEXPORT jstring JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_de
  * @param jModel Memory address of the LLM.
  * @return Boolean that is true if the token is special, false otherwise.
  */
-extern "C" JNIEXPORT jboolean JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_isSpecial(JNIEnv* env, jobject thiz, jint token, jlong jModel) {
+extern "C" JNIEXPORT jboolean JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_isSpecial(JNIEnv* /* env */, jobject /* thiz */, jint token, jlong jModel) {
     // Cast memory address of the LLM from Java long to C++ pointer
     auto cppModel = reinterpret_cast<llama_model*>(jModel);
 
@@ -290,7 +290,7 @@ extern "C" JNIEXPORT jboolean JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_i
  * @param jCtx Memory address of the context.
  * @return The logit matrix.
  */
-extern "C" JNIEXPORT jobjectArray JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_getLogits(JNIEnv* env, jobject thiz, jintArray jTokens, jlong jCtx) {
+extern "C" JNIEXPORT jobjectArray JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_getLogits(JNIEnv* env, jobject /* thiz */, jintArray jTokens, jlong jCtx) {
     // Cast memory addresses of context from Java long to C++ pointer
     auto cppCtx = reinterpret_cast<llama_context*>(jCtx);
 
@@ -378,7 +378,7 @@ extern "C" JNIEXPORT jobjectArray JNICALL Java_org_vonderheidt_hips_utils_LlamaC
  * @param jSmpl Memory address of the sampler.
  * @return ID of the next token.
  */
-extern "C" JNIEXPORT jint JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_sample(JNIEnv* env, jobject thiz, jint lastToken, jlong jCtx, jlong jSmpl) {
+extern "C" JNIEXPORT jint JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_sample(JNIEnv* /* env */, jobject /* thiz */, jint lastToken, jlong jCtx, jlong jSmpl) {
     // Cast memory addresses of context and sampler from Java long to C++ pointers
     // Casting the last token ID from jint to llama_token is not necessary since both is just int32_t
     auto cppCtx = reinterpret_cast<llama_context*>(jCtx);

--- a/app/src/main/cpp/hips.cpp
+++ b/app/src/main/cpp/hips.cpp
@@ -206,9 +206,8 @@ extern "C" JNIEXPORT jintArray JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_
     const char* cppString = env -> GetStringUTFChars(jString, &isCopy);
 
     // Tokenize string, save tokens as llama_tokens (equivalent to std::vector<llama_token>, with llama_token equivalent to int32_t)
-    // Hide special tokens to get clean input
-    // See common.cpp: common_tokenize(ctx, ...) calls common_tokenize(vocab, ...), which calls llama_tokenize
-    llama_tokens cppTokens = common_tokenize(cppCtx, cppString, false, false);
+    // See common.cpp: common_tokenize(ctx, ...) calls common_tokenize(vocab, ...), which calls llama_tokenize, always passing parameters {add,parse}_special through
+    llama_tokens cppTokens = common_tokenize(cppCtx, cppString, false, true);
 
     // Release C++ string from memory
     env -> ReleaseStringUTFChars(jString, cppString);
@@ -242,9 +241,9 @@ extern "C" JNIEXPORT jstring JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_de
 
     env -> GetIntArrayRegion(jTokens, 0, jTokensSize, reinterpret_cast<jint*>(cppTokens.data()));
 
-    // Detokenize array of tokens to C++ string, hide special tokens to get clean output
-    // See common.cpp: common_detokenize calls llama_detokenize
-    std::basic_string<char> cppString = common_detokenize(cppCtx, cppTokens, false);
+    // Detokenize array of tokens to C++ string
+    // See common.cpp: common_detokenize calls llama_detokenize, with parameters "remove_special = false" hard-coded and "unparse_special = special" passed through
+    std::basic_string<char> cppString = common_detokenize(cppCtx, cppTokens, true);
 
     // Convert C++ string to Java string and return it
     jstring jString = env -> NewStringUTF(cppString.c_str());

--- a/app/src/main/cpp/hips.cpp
+++ b/app/src/main/cpp/hips.cpp
@@ -207,7 +207,7 @@ extern "C" JNIEXPORT jintArray JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_
 
     // Tokenize string, save tokens as llama_tokens (equivalent to std::vector<llama_token>, with llama_token equivalent to int32_t)
     // Hide special tokens to get clean input
-    // See common.cpp: common_tokenize(ctx, ...) calls common_tokenize(model, ...), which calls llama_tokenize
+    // See common.cpp: common_tokenize(ctx, ...) calls common_tokenize(vocab, ...), which calls llama_tokenize
     llama_tokens cppTokens = common_tokenize(cppCtx, cppString, false, false);
 
     // Release C++ string from memory

--- a/app/src/main/cpp/hips.cpp
+++ b/app/src/main/cpp/hips.cpp
@@ -268,9 +268,12 @@ extern "C" JNIEXPORT jboolean JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_i
     // Get model the context was created with
     const llama_model* model = llama_get_model(cppCtx);
 
+    // Get vocabulary of the model
+    const llama_vocab* vocab = llama_model_get_vocab(model);
+
     // Check if token is special
     // Token ID doesn't need casting because jint and llama_token are both just int32_t
-    bool cppIsSpecial = llama_token_is_eog(model, token) || llama_token_is_control(model,token);
+    bool cppIsSpecial = llama_vocab_is_eog(vocab, token) || llama_vocab_is_control(vocab, token);
 
     // Cast boolean to return it
     // static_cast because casting booleans is type safe, unlike reinterpret_cast for casting C++ pointers to Java long
@@ -298,6 +301,9 @@ extern "C" JNIEXPORT jobjectArray JNICALL Java_org_vonderheidt_hips_utils_LlamaC
     // No need to specify cppModel in variable name as there is no jModel
     const llama_model* model = llama_get_model(cppCtx);
 
+    // Get vocabulary of the model
+    const llama_vocab* vocab = llama_model_get_vocab(model);
+
     // Copy token IDs from Java array to C++ array
     // Data types jint, jsize and int32_t are all equivalent
     jint* cppTokens = env -> GetIntArrayElements(jTokens, nullptr);
@@ -305,7 +311,7 @@ extern "C" JNIEXPORT jobjectArray JNICALL Java_org_vonderheidt_hips_utils_LlamaC
     // C++ allows accessing illegal array indices and returns garbage values, doesn't throw IndexOutOfBoundsException like Java/Kotlin
     // Manually ensure that indices stay within dimensions n_tokens x n_vocab of the logit matrix
     jsize n_tokens = env -> GetArrayLength(jTokens);
-    int32_t n_vocab = llama_n_vocab(model);
+    int32_t n_vocab = llama_vocab_n_tokens(vocab);
 
     // Store tokens to be processed in batch data structure
     // llama.cpp example cited below stores multiple tokens from tokenization of the prompt in the first run, single last sampled token in subsequent runs

--- a/app/src/main/cpp/hips.cpp
+++ b/app/src/main/cpp/hips.cpp
@@ -258,18 +258,15 @@ extern "C" JNIEXPORT jstring JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_de
  * @param env The JNI environment.
  * @param thiz Java object this function was called with.
  * @param token Token ID to check.
- * @param jCtx Memory address of the context.
- * @return Boolean that is true if the token special, false otherwise.
+ * @param jModel Memory address of the LLM.
+ * @return Boolean that is true if the token is special, false otherwise.
  */
-extern "C" JNIEXPORT jboolean JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_isSpecial(JNIEnv* env, jobject thiz, jint token, jlong jCtx) {
-    // Cast memory address of the context from Java long to C++ pointer
-    auto cppCtx = reinterpret_cast<llama_context*>(jCtx);
+extern "C" JNIEXPORT jboolean JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_isSpecial(JNIEnv* env, jobject thiz, jint token, jlong jModel) {
+    // Cast memory address of the LLM from Java long to C++ pointer
+    auto cppModel = reinterpret_cast<llama_model*>(jModel);
 
-    // Get model the context was created with
-    const llama_model* model = llama_get_model(cppCtx);
-
-    // Get vocabulary of the model
-    const llama_vocab* vocab = llama_model_get_vocab(model);
+    // Get vocabulary of the LLM
+    const llama_vocab* vocab = llama_model_get_vocab(cppModel);
 
     // Check if token is special
     // Token ID doesn't need casting because jint and llama_token are both just int32_t

--- a/app/src/main/cpp/hips.cpp
+++ b/app/src/main/cpp/hips.cpp
@@ -214,10 +214,10 @@ extern "C" JNIEXPORT jintArray JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_
     env -> ReleaseStringUTFChars(jString, cppString);
 
     // Initialize Java int array to store token IDs
-    jintArray jTokens = env -> NewIntArray(cppTokens.size());
+    jintArray jTokens = env -> NewIntArray((int32_t) cppTokens.size());
 
     // Fill the Java array with token IDs and return it
-    env -> SetIntArrayRegion(jTokens, 0, cppTokens.size(), reinterpret_cast<const jint*>(cppTokens.data()));
+    env -> SetIntArrayRegion(jTokens, 0, (int32_t) cppTokens.size(), reinterpret_cast<const jint*>(cppTokens.data()));
 
     return jTokens;
 }

--- a/app/src/main/java/org/vonderheidt/hips/MainActivity.kt
+++ b/app/src/main/java/org/vonderheidt/hips/MainActivity.kt
@@ -8,11 +8,15 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.vonderheidt.hips.data.HiPSDataStore
 import org.vonderheidt.hips.data.HiPSDatabase
 import org.vonderheidt.hips.navigation.SetupNavGraph
 import org.vonderheidt.hips.ui.theme.HiPSTheme
+import org.vonderheidt.hips.utils.LLM
+import org.vonderheidt.hips.utils.LlamaCpp
 
 /**
  * Class that defines the entry point into the app and calls the main screen.
@@ -35,6 +39,11 @@ class MainActivity : ComponentActivity() {
                     SetupNavGraph(modifier)
                 }
             }
+        }
+
+        // Load LLM on app startup
+        if (LLM.isDownloaded()) {
+            CoroutineScope(Dispatchers.IO).launch { LlamaCpp.startInstance() }
         }
 
         // Instantiate Room database on app startup

--- a/app/src/main/java/org/vonderheidt/hips/data/HiPSDataStore.kt
+++ b/app/src/main/java/org/vonderheidt/hips/data/HiPSDataStore.kt
@@ -23,6 +23,7 @@ object HiPSDataStore {
 
     // Define the data type of the values for each setting by declaring the corresponding keys
     private val conversionMode = stringPreferencesKey("conversionMode")
+    private val systemPrompt = stringPreferencesKey("systemPrompt")
     private val steganographyMode = stringPreferencesKey("steganographyMode")
     private val temperature = floatPreferencesKey("temperature")
     private val blockSize = intPreferencesKey("blockSize")
@@ -62,6 +63,7 @@ object HiPSDataStore {
         // Instance can be asserted not null because startInstance initializes it in MainActivity (i.e. on app startup)
         instance!!.data.map { settings ->
             val conversionMode = settings[conversionMode]
+            val systemPrompt = settings[systemPrompt]
             val steganographyMode = settings[steganographyMode]
             val temperature = settings[temperature]
             val blockSize = settings[blockSize]
@@ -69,6 +71,7 @@ object HiPSDataStore {
 
             // See if any settings are currently stored by checking for null values
             val isInitialized = conversionMode != null
+                    && systemPrompt != null
                     && steganographyMode != null
                     && temperature != null
                     && blockSize != null
@@ -78,6 +81,7 @@ object HiPSDataStore {
             if (isInitialized) {
                 // Can be asserted not null because of check with isInitialized
                 Settings.conversionMode = ConversionMode.valueOf(conversionMode!!)
+                Settings.systemPrompt = systemPrompt!!
                 Settings.steganographyMode = SteganographyMode.valueOf(steganographyMode!!)
                 Settings.temperature = temperature!!
                 Settings.blockSize = blockSize!!
@@ -97,6 +101,7 @@ object HiPSDataStore {
         // Instance can be asserted not null because startInstance initializes it in MainActivity (i.e. on app startup)
         instance!!.edit { settings ->
             settings[conversionMode] = Settings.conversionMode.name
+            settings[systemPrompt] = Settings.systemPrompt
             settings[steganographyMode] = Settings.steganographyMode.name
             settings[temperature] = Settings.temperature
             settings[blockSize] = Settings.blockSize

--- a/app/src/main/java/org/vonderheidt/hips/data/HiPSDataStore.kt
+++ b/app/src/main/java/org/vonderheidt/hips/data/HiPSDataStore.kt
@@ -24,6 +24,7 @@ object HiPSDataStore {
     // Define the data type of the values for each setting by declaring the corresponding keys
     private val conversionMode = stringPreferencesKey("conversionMode")
     private val systemPrompt = stringPreferencesKey("systemPrompt")
+    private val numberOfMessages = intPreferencesKey("numberOfMessages")
     private val steganographyMode = stringPreferencesKey("steganographyMode")
     private val temperature = floatPreferencesKey("temperature")
     private val blockSize = intPreferencesKey("blockSize")
@@ -64,6 +65,7 @@ object HiPSDataStore {
         instance!!.data.map { settings ->
             val conversionMode = settings[conversionMode]
             val systemPrompt = settings[systemPrompt]
+            val numberOfMessages = settings[numberOfMessages]
             val steganographyMode = settings[steganographyMode]
             val temperature = settings[temperature]
             val blockSize = settings[blockSize]
@@ -72,6 +74,7 @@ object HiPSDataStore {
             // See if any settings are currently stored by checking for null values
             val isInitialized = conversionMode != null
                     && systemPrompt != null
+                    && numberOfMessages != null
                     && steganographyMode != null
                     && temperature != null
                     && blockSize != null
@@ -82,6 +85,7 @@ object HiPSDataStore {
                 // Can be asserted not null because of check with isInitialized
                 Settings.conversionMode = ConversionMode.valueOf(conversionMode!!)
                 Settings.systemPrompt = systemPrompt!!
+                Settings.numberOfMessages = numberOfMessages!!
                 Settings.steganographyMode = SteganographyMode.valueOf(steganographyMode!!)
                 Settings.temperature = temperature!!
                 Settings.blockSize = blockSize!!
@@ -102,6 +106,7 @@ object HiPSDataStore {
         instance!!.edit { settings ->
             settings[conversionMode] = Settings.conversionMode.name
             settings[systemPrompt] = Settings.systemPrompt
+            settings[numberOfMessages] = Settings.numberOfMessages
             settings[steganographyMode] = Settings.steganographyMode.name
             settings[temperature] = Settings.temperature
             settings[blockSize] = Settings.blockSize

--- a/app/src/main/java/org/vonderheidt/hips/data/Settings.kt
+++ b/app/src/main/java/org/vonderheidt/hips/data/Settings.kt
@@ -13,6 +13,7 @@ object Settings {
         Use phrases and abbreviations typical for chat messages.
         Be brief and casual, but friendly and engaging.
     """.trimIndent().replace("\n", " ")
+    var numberOfMessages = 0
     var steganographyMode = SteganographyMode.Arithmetic
     var temperature = 0.9f
     var blockSize = 3

--- a/app/src/main/java/org/vonderheidt/hips/data/Settings.kt
+++ b/app/src/main/java/org/vonderheidt/hips/data/Settings.kt
@@ -7,9 +7,9 @@ import org.vonderheidt.hips.utils.SteganographyMode
  * Object (i.e. singleton class) that represents the user settings. Holds default values to be set upon installation of this app.
  */
 object Settings {
-    var conversionMode: ConversionMode = ConversionMode.Arithmetic
-    var steganographyMode: SteganographyMode = SteganographyMode.Arithmetic
-    var temperature: Float = 0.9f
-    var blockSize: Int = 3
-    var bitsPerToken: Int = 3
+    var conversionMode = ConversionMode.Arithmetic
+    var steganographyMode = SteganographyMode.Arithmetic
+    var temperature = 0.9f
+    var blockSize = 3
+    var bitsPerToken = 3
 }

--- a/app/src/main/java/org/vonderheidt/hips/data/Settings.kt
+++ b/app/src/main/java/org/vonderheidt/hips/data/Settings.kt
@@ -8,6 +8,11 @@ import org.vonderheidt.hips.utils.SteganographyMode
  */
 object Settings {
     var conversionMode = ConversionMode.Arithmetic
+    var systemPrompt = """
+        You and I are friends, talking about what we did on the weekend.
+        Use phrases and abbreviations typical for chat messages.
+        Be brief and casual, but friendly and engaging.
+    """.trimIndent().replace("\n", " ")
     var steganographyMode = SteganographyMode.Arithmetic
     var temperature = 0.9f
     var blockSize = 3

--- a/app/src/main/java/org/vonderheidt/hips/data/User.kt
+++ b/app/src/main/java/org/vonderheidt/hips/data/User.kt
@@ -13,4 +13,16 @@ import androidx.room.PrimaryKey
 data class User(
     @PrimaryKey val id: Int,
     val name: String
-)
+) {
+    companion object {
+        /**
+         * Sample user for the conversation screen.
+         */
+        val Alice = User(0, "Alice")
+
+        /**
+         * Sample user for the conversation screen.
+         */
+        val Bob = User(1, "Bob")
+    }
+}

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
@@ -152,6 +152,11 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                 // Decode button
                 IconButton(
                     onClick = {
+                        // Check if LLM is loaded
+                        if (!LlamaCpp.isInMemory()) {
+                            Toast.makeText(currentLocalContext, "Load LLM into memory first", Toast.LENGTH_LONG).show()
+                            return@IconButton
+                        }
                         // Only 1 message can be decoded at a time
                         if (selectedMessages.size != 1) {
                             Toast.makeText(currentLocalContext, "Only 1 message can be decoded at a time", Toast.LENGTH_LONG).show()

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
@@ -159,7 +159,8 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                         else {
                             Toast.makeText(currentLocalContext, "Only 1 message can be decoded at a time", Toast.LENGTH_LONG).show()
                         }
-                    }
+                    },
+                    enabled = !isEncoding
                 ) {
                     Icon(
                         imageVector = Icons.Outlined.Visibility,
@@ -185,7 +186,8 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                         else {
                             Toast.makeText(currentLocalContext, "Only messages at the end can be deleted", Toast.LENGTH_LONG).show()
                         }
-                    }
+                    },
+                    enabled = !isEncoding
                 ) {
                     Icon(
                         imageVector = Icons.Outlined.Delete,
@@ -262,9 +264,10 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                 value = newMessageContent,
                 onValueChange = { newMessageContent = it },
                 modifier = modifier.weight(1f),
+                enabled = !isEncoding,
                 label = { Text(text = "New message") },
                 trailingIcon = {
-                    if (newMessageContent.isNotEmpty()) {
+                    if (newMessageContent.isNotEmpty() && !isEncoding) {
                         Icon(
                             imageVector = Icons.Outlined.Clear,
                             contentDescription = "Clear new message",
@@ -286,7 +289,8 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                         .background(
                             color = if (isAlice) Color(0xFF2E7D32) else Color(0xFFB71C1C),
                             shape = CircleShape
-                        )
+                        ),
+                    enabled = !isEncoding
                 ) {
                     // Show loading animation while encoding
                     if (isEncoding) {

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
@@ -153,12 +153,12 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                 IconButton(
                     onClick = {
                         // Only 1 message can be decoded at a time
-                        if (selectedMessages.size == 1) {
-                            Toast.makeText(currentLocalContext, "Secret message encoded in ${selectedMessages[0].content}", Toast.LENGTH_LONG).show()
-                        }
-                        else {
+                        if (selectedMessages.size != 1) {
                             Toast.makeText(currentLocalContext, "Only 1 message can be decoded at a time", Toast.LENGTH_LONG).show()
+                            return@IconButton
                         }
+
+                        Toast.makeText(currentLocalContext, "Secret message encoded in ${selectedMessages[0].content}", Toast.LENGTH_LONG).show()
                     },
                     enabled = !isEncoding
                 ) {

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
@@ -61,6 +61,12 @@ import org.vonderheidt.hips.ui.theme.HiPSTheme
  */
 @Composable
 fun ConversationScreen(navController: NavController, modifier: Modifier) {
+    // State variables
+    var messages by rememberSaveable { mutableStateOf(listOf<Message>()) }
+    var selectedMessages by rememberSaveable { mutableStateOf(listOf<Message>()) }
+    var newMessageContent by rememberSaveable { mutableStateOf("") }
+    var isAlice by rememberSaveable { mutableStateOf(true) }
+
     // Database
     val db = HiPSDatabase.getInstance()
 
@@ -69,12 +75,6 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
 
     // Toasts
     val currentLocalContext = LocalContext.current
-
-    // State variables
-    var messages by rememberSaveable { mutableStateOf(listOf<Message>()) }
-    var selectedMessages by rememberSaveable { mutableStateOf(listOf<Message>()) }
-    var newMessageContent by rememberSaveable { mutableStateOf("") }
-    var isAlice by rememberSaveable { mutableStateOf(true) }
 
     // Query messages from database upon composition of this screen
     // Unit parameter allows query to be only run once

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
@@ -177,20 +177,20 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                 IconButton(
                     onClick = {
                         // Only last messages of the conversation can be deleted, otherwise context would be corrupted
-                        if (messages.takeLast(selectedMessages.size) == selectedMessages) {
-                            // Update database
-                            // Inverse encapsulation of loop vs coroutine causes messages to not be deleted
-                            for (selectedMessage in selectedMessages) {
-                                coroutineScope.launch { db.messageDao.deleteMessage(selectedMessage) }
-                            }
-
-                            // Update state variables
-                            messages = messages.dropLast(selectedMessages.size)
-                            selectedMessages = listOf()
-                        }
-                        else {
+                        if (messages.takeLast(selectedMessages.size) != selectedMessages) {
                             Toast.makeText(currentLocalContext, "Only messages at the end can be deleted", Toast.LENGTH_LONG).show()
+                            return@IconButton
                         }
+
+                        // Update database
+                        // Inverse encapsulation of loop vs coroutine causes messages to not be deleted
+                        for (selectedMessage in selectedMessages) {
+                            coroutineScope.launch { db.messageDao.deleteMessage(selectedMessage) }
+                        }
+
+                        // Update state variables
+                        messages = messages.dropLast(selectedMessages.size)
+                        selectedMessages = listOf()
                     },
                     enabled = !isEncoding
                 ) {

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
@@ -57,6 +57,7 @@ import org.vonderheidt.hips.data.Message
 import org.vonderheidt.hips.data.User
 import org.vonderheidt.hips.navigation.Screen
 import org.vonderheidt.hips.ui.theme.HiPSTheme
+import org.vonderheidt.hips.utils.LlamaCpp
 
 /**
  * Function that defines the conversation screen.
@@ -274,6 +275,11 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
             // Colour corresponds to user a new message is being sent as
             IconButton(
                 onClick = {
+                    // Check if LLM is loaded
+                    if (!LlamaCpp.isInMemory()) {
+                        Toast.makeText(currentLocalContext, "Load LLM into memory first", Toast.LENGTH_LONG).show()
+                        return@IconButton
+                    }
                     // Only send non-blank messages, allows to switch user on button press
                     if (newMessageContent.isBlank()) {
                         // Clear input field and change mode

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
@@ -274,31 +274,35 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
             // Colour corresponds to user a new message is being sent as
             IconButton(
                 onClick = {
-                    // Only send non-blank messages
-                    // Allows to switch user on button press
-                    if (newMessageContent.isNotBlank()) {
-                        // Create data objects for sender, receiver and message
-                        val newSender = if (isAlice) User.Alice else User.Bob
-                        val newReceiver = if (isAlice) User.Bob else User.Alice
+                    // Only send non-blank messages, allows to switch user on button press
+                    if (newMessageContent.isBlank()) {
+                        // Clear input field and change mode
+                        newMessageContent = ""
+                        isAlice = !isAlice
+                        return@IconButton
+                    }
 
-                        val newMessage = Message(
-                            senderID = newSender.id,
-                            receiverID = newReceiver.id,
-                            timestamp = System.currentTimeMillis(),
-                            content = newMessageContent
-                        )
+                    // Create data objects for sender, receiver and message
+                    val newSender = if (isAlice) User.Alice else User.Bob
+                    val newReceiver = if (isAlice) User.Bob else User.Alice
 
-                        // Update state variable
-                        messages += newMessage
+                    val newMessage = Message(
+                        senderID = newSender.id,
+                        receiverID = newReceiver.id,
+                        timestamp = System.currentTimeMillis(),
+                        content = newMessageContent
+                    )
 
-                        // Update database
-                        // Launch queries in coroutine so they can't block the UI in the main thread
-                        coroutineScope.launch {
-                            // Order is important to avoid violating foreign key relations
-                            db.userDao.upsertUser(newSender)
-                            db.userDao.upsertUser(newReceiver)
-                            db.messageDao.upsertMessage(newMessage)
-                        }
+                    // Update state variable
+                    messages += newMessage
+
+                    // Update database
+                    // Launch queries in coroutine so they can't block the UI in the main thread
+                    coroutineScope.launch {
+                        // Order is important to avoid violating foreign key relations
+                        db.userDao.upsertUser(newSender)
+                        db.userDao.upsertUser(newReceiver)
+                        db.messageDao.upsertMessage(newMessage)
                     }
 
                     // Clear input field and change mode

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
@@ -283,11 +283,7 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                                 shape = RoundedCornerShape(4.dp)
                             )
                             .graphicsLayer(
-                                alpha = if (selectedMessages.isEmpty()) { 1f }
-                                        else {
-                                            if (message in selectedMessages) { 1f }
-                                            else { 0.25f }
-                                        }
+                                alpha = if (selectedMessages.isEmpty() || message in selectedMessages) { 1f } else { 0.25f }
                             )
                             .padding(8.dp)
                             .pointerInput(Unit) {

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
@@ -75,7 +75,7 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
     // State variables
     var messages by rememberSaveable { mutableStateOf(listOf<Message>()) }
     var selectedMessages by rememberSaveable { mutableStateOf(listOf<Message>()) }
-    var newMessageContent by rememberSaveable { mutableStateOf("") }
+    var newSecretMessage by rememberSaveable { mutableStateOf("") }
     var isAlice by rememberSaveable { mutableStateOf(true) }
     var isPlainText by rememberSaveable { mutableStateOf(false) }
     var isEncoding by rememberSaveable { mutableStateOf(false) }
@@ -343,17 +343,17 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
         ) {
             // Input field for new message
             OutlinedTextField(
-                value = newMessageContent,
-                onValueChange = { newMessageContent = it },
+                value = newSecretMessage,
+                onValueChange = { newSecretMessage = it },
                 modifier = modifier.weight(1f),
                 enabled = !(isEncoding || isDecoding),
                 label = { Text(text = "New message") },
                 trailingIcon = {
-                    if (newMessageContent.isNotEmpty() && !(isEncoding || isDecoding)) {
+                    if (newSecretMessage.isNotEmpty() && !(isEncoding || isDecoding)) {
                         Icon(
                             imageVector = Icons.Outlined.Clear,
                             contentDescription = "Clear new message",
-                            modifier = modifier.clickable { newMessageContent = "" }
+                            modifier = modifier.clickable { newSecretMessage = "" }
                         )
                     }
                 },
@@ -401,9 +401,9 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                                             return@detectTapGestures
                                         }
                                         // Only send non-blank messages, allows to switch user on button press
-                                        if (newMessageContent.isBlank()) {
+                                        if (newSecretMessage.isBlank()) {
                                             // Clear input field and change mode
-                                            newMessageContent = ""
+                                            newSecretMessage = ""
                                             isAlice = !isAlice
                                             return@detectTapGestures
                                         }
@@ -432,7 +432,7 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                                             val context = LlamaCpp.formatChat(messages, isAlice)
 
                                             // Generate cover text and write it into chat history
-                                            val newCoverText = if (isPlainText) newMessageContent else Steganography.encode(context, newMessageContent)
+                                            val newCoverText = if (isPlainText) newSecretMessage else Steganography.encode(context, newSecretMessage)
 
                                             val newMessage = Message(
                                                 senderID = newSender.id,
@@ -450,7 +450,7 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                                             db.messageDao.upsertMessage(newMessage)
 
                                             // Clear input field and change mode
-                                            newMessageContent = ""
+                                            newSecretMessage = ""
                                             isAlice = !isAlice
 
                                             isEncoding = false

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
@@ -41,8 +41,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -75,6 +77,9 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
 
     // Toasts
     val currentLocalContext = LocalContext.current
+
+    // Vibration
+    val hapticFeedback = LocalHapticFeedback.current
 
     // Query messages from database upon composition of this screen
     // Unit parameter allows query to be only run once
@@ -217,6 +222,9 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                             .pointerInput(Unit) {
                                 detectTapGestures(
                                     onLongPress = {
+                                        // Vibrate
+                                        hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+
                                         // List of selected messages has to be sorted because list of messages is sorted, otherwise couldn't be compared to its end
                                         selectedMessages += message
                                         selectedMessages = selectedMessages.sortedBy { it.timestamp }

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
@@ -113,6 +113,13 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
         ) {
             IconButton(
                 onClick = {
+                    // Reset state variables, just like when decode button is hidden, otherwise app crashes when pressing the back button while a secret message is visible
+                    // Only "messageToDecode = null" is actually needed, but reset others too for consistency
+                    isSecretMessageVisible = false
+                    secretMessage = ""
+                    messageToDecode = null
+                    selectedMessages = listOf()
+
                     // Navigate back to home screen
                     navController.navigate(Screen.Home.route) {
                         // Empty back stack, including home screen
@@ -222,6 +229,12 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                         // Update state variables
                         messages = messages.dropLast(selectedMessages.size)
                         selectedMessages = listOf()
+
+                        // Reset state variables, just like when decode button is hidden, otherwise secretMessage is still visible after deleting other messages
+                        isSecretMessageVisible = false
+                        secretMessage = ""
+                        messageToDecode = null
+                        // "selectedMessages = listOf()" is redundant
                     },
                     enabled = !(isEncoding || isDecoding)
                 ) {
@@ -276,6 +289,14 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                                     },
                                     onTap = {
                                         selectedMessages -= message
+
+                                        // Reset state variables, just like when decode button is hidden, otherwise secret message is still visible when last message is unselected
+                                        if (selectedMessages.isEmpty()) {
+                                            isSecretMessageVisible = false
+                                            secretMessage = ""
+                                            messageToDecode = null
+                                            // "selectedMessages = listOf()" is redundant
+                                        }
                                     }
                                 )
                             }
@@ -375,6 +396,14 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                                         }
 
                                         isEncoding = true
+
+                                        // Reset state variables, just like when decode button is hidden, otherwise secret message is still visible after send button is pressed
+                                        if (selectedMessages.isNotEmpty()) {
+                                            isSecretMessageVisible = false
+                                            secretMessage = ""
+                                            messageToDecode = null
+                                            selectedMessages = listOf()
+                                        }
 
                                         // Create data objects for sender, receiver and message
                                         val newSender = if (isAlice) User.Alice else User.Bob

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
@@ -74,12 +74,12 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
     var messages by rememberSaveable { mutableStateOf(listOf<Message>()) }
     var selectedMessages by rememberSaveable { mutableStateOf(listOf<Message>()) }
     var newMessageContent by rememberSaveable { mutableStateOf("") }
-    var isSender by rememberSaveable { mutableStateOf(true) }
+    var isAlice by rememberSaveable { mutableStateOf(true) }
 
     // Query messages from database upon composition of this screen
     // Unit parameter allows query to be only run once
     LaunchedEffect(Unit) {
-        messages = db.messageDao.getConversation(0, 1)
+        messages = db.messageDao.getConversation(User.Alice.id, User.Bob.id)
     }
 
     // UI components
@@ -197,13 +197,13 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
             items(messages) { message ->
                 Row(
                     modifier = modifier.fillMaxWidth(),
-                    horizontalArrangement = if (message.senderID == 0) Arrangement.End else Arrangement.Start
+                    horizontalArrangement = if (message.senderID == User.Alice.id) Arrangement.End else Arrangement.Start
                 ) {
                     Box(
                         modifier = modifier
                             .fillMaxWidth(0.9f)
                             .background(
-                                color = if (message.senderID == 0) Color(0xFF2E7D32) else Color(0xFFB71C1C),
+                                color = if (message.senderID == User.Alice.id) Color(0xFF2E7D32) else Color(0xFFB71C1C),
                                 shape = RoundedCornerShape(4.dp)
                             )
                             .graphicsLayer(
@@ -270,8 +270,8 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                     // Allows to switch user on button press
                     if (newMessageContent.isNotBlank()) {
                         // Create data objects for sender, receiver and message
-                        val newSender = if (isSender) User(0, "Alice") else User(1, "Bob")
-                        val newReceiver = if (isSender) User(1, "Bob") else User(0, "Alice")
+                        val newSender = if (isAlice) User.Alice else User.Bob
+                        val newReceiver = if (isAlice) User.Bob else User.Alice
 
                         val newMessage = Message(
                             senderID = newSender.id,
@@ -295,11 +295,11 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
 
                     // Clear input field and change mode
                     newMessageContent = ""
-                    isSender = !isSender
+                    isAlice = !isAlice
                 },
                 modifier = modifier
                     .background(
-                        color = if (isSender) Color(0xFF2E7D32) else Color(0xFFB71C1C),
+                        color = if (isAlice) Color(0xFF2E7D32) else Color(0xFFB71C1C),
                         shape = CircleShape
                     )
             ) {

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
@@ -347,7 +347,7 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                 onValueChange = { newSecretMessage = it },
                 modifier = modifier.weight(1f),
                 enabled = !(isEncoding || isDecoding),
-                label = { Text(text = "New message") },
+                label = { Text(text = if (isPlainText) "New plain text" else "New secret message") },
                 trailingIcon = {
                     if (newSecretMessage.isNotEmpty() && !(isEncoding || isDecoding)) {
                         Icon(

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
@@ -279,7 +279,7 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                         modifier = modifier
                             .fillMaxWidth(0.9f)
                             .background(
-                                color = if (message.senderID == User.Alice.id) Color(0xFF2E7D32) else Color(0xFFB71C1C),
+                                color = if (message.senderID == User.Alice.id) Color(0xFF00695C) else Color(0xFFAD1457),
                                 shape = RoundedCornerShape(4.dp)
                             )
                             .graphicsLayer(
@@ -369,7 +369,7 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                     onClick = { /* See onTap of Icon */ },
                     modifier = modifier
                         .background(
-                            color = if (isAlice) Color(0xFF2E7D32) else Color(0xFFB71C1C),
+                            color = if (isAlice) Color(0xFF00695C) else Color(0xFFAD1457),
                             shape = CircleShape
                         ),
                     enabled = !(isEncoding || isDecoding)

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
@@ -354,6 +354,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
 
                 Spacer(modifier = modifier.height(16.dp))
 
+                // Slider only allows floats, do int conversion here to abstract it away from state variable
                 Slider(
                     value = selectedNumberOfMessages.toFloat(),
                     onValueChange = {
@@ -453,7 +454,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
 
                         Spacer(modifier = modifier.height(16.dp))
 
-                        // Slider only allows floats, do int conversion here to abstract it away from state variable
+                        // Again, do int conversion here as slider only allows floats
                         Slider(
                             value = selectedBlockSize.toFloat(),
                             onValueChange = {

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
@@ -445,9 +445,12 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                             steps = 19
                         )
 
-                        Spacer(modifier = modifier.height(16.dp))
+                        Spacer(modifier = modifier.height(8.dp))
 
-                        Text(text = "T = $selectedTemperature")
+                        Text(
+                            text = "$selectedTemperature",
+                            modifier = modifier.align(Alignment.CenterHorizontally)
+                        )
                     }
                     SteganographyMode.Bins -> {
                         Text(text = "Set the number of bins (higher is more efficient, but less coherent).")
@@ -469,9 +472,18 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                             steps = 2
                         )
 
-                        Spacer(modifier = modifier.height(16.dp))
+                        Spacer(modifier = modifier.height(8.dp))
 
-                        Text(text = "n = 2^$selectedBlockSize bins")
+                        Text(
+                            text = "2" + when (selectedBlockSize) {
+                                1 -> "¹"
+                                2 -> "²"
+                                3 -> "³"
+                                4 -> "⁴"
+                                else -> throw IllegalStateException("Selected block size has to be between 1 and 4")
+                            } + " bins",
+                            modifier = modifier.align(Alignment.CenterHorizontally)
+                        )
                     }
                     SteganographyMode.Huffman -> {
                         Text(text = "Set the bits per token (higher is more efficient, but less coherent).")
@@ -493,9 +505,12 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                             steps = 2
                         )
 
-                        Spacer(modifier = modifier.height(16.dp))
+                        Spacer(modifier = modifier.height(8.dp))
 
-                        Text(text = "n = $selectedBitsPerToken bits/token")
+                        Text(
+                            text = "$selectedBitsPerToken " + if (selectedBitsPerToken == 1) "bit/token" else "bits/token",
+                            modifier = modifier.align(Alignment.CenterHorizontally)
+                        )
                     }
                 }
             }

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
@@ -2,6 +2,7 @@ package org.vonderheidt.hips.ui.screens
 
 import android.content.Intent
 import android.net.Uri
+import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -18,6 +19,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.Clear
 import androidx.compose.material.icons.outlined.Key
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Pause
@@ -29,6 +31,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
@@ -71,6 +74,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
     var isDownloaded by rememberSaveable { mutableStateOf(LLM.isDownloaded()) }
     var isInMemory by rememberSaveable { mutableStateOf(LlamaCpp.isInMemory()) }
     var selectedConversionMode by rememberSaveable { mutableStateOf(Settings.conversionMode) }
+    var systemPrompt by rememberSaveable { mutableStateOf(Settings.systemPrompt) }
     var selectedSteganographyMode by rememberSaveable { mutableStateOf(Settings.steganographyMode) }
     var selectedTemperature by rememberSaveable { mutableFloatStateOf(Settings.temperature) }
     var selectedBlockSize by rememberSaveable { mutableIntStateOf(Settings.blockSize) }
@@ -292,6 +296,57 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                     fontSize = 18.sp,
                     fontWeight = FontWeight.Bold
                 )
+
+                // Set system prompt
+                Text(text = "Set the system prompt to define the role the LLM takes in a conversation.")
+
+                Spacer(modifier = modifier.height(16.dp))
+
+                OutlinedTextField(
+                    value = systemPrompt,
+                    onValueChange = {
+                        // Update state variable
+                        systemPrompt = it
+                    },
+                    modifier = modifier.fillMaxWidth(),
+                    label = { Text(text = "System prompt") },
+                    trailingIcon = {
+                        if (systemPrompt.isNotEmpty()) {
+                            Icon(
+                                imageVector = Icons.Outlined.Clear,
+                                contentDescription = "Clear system prompt",
+                                modifier = modifier.clickable {
+                                    // Update state variable
+                                    systemPrompt = ""
+                                }
+                            )
+                        }
+                    },
+                    maxLines = 5
+                )
+
+                Spacer(modifier = modifier.height(8.dp))
+
+                Button(
+                    onClick = {
+                        if (systemPrompt.isBlank()) {
+                            Toast.makeText(currentLocalContext, "System prompt can't be blank", Toast.LENGTH_LONG).show()
+                            return@Button
+                        }
+
+                        // Update DataStore
+                        Settings.systemPrompt = systemPrompt
+                        coroutineScope.launch { HiPSDataStore.writeSettings() }
+
+                        Toast.makeText(currentLocalContext, "System prompt saved", Toast.LENGTH_LONG).show()
+                    },
+                    modifier = modifier.align(Alignment.End),
+                    shape = RoundedCornerShape(4.dp)
+                ) {
+                    Text(text = "Save")
+                }
+
+                Spacer(modifier = modifier.height(16.dp))
 
                 Text(text = "Select how to encode the secret message into a cover text.")
 

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
@@ -213,20 +213,20 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
             Spacer(modifier = modifier.height(16.dp))
         }
 
-        // Steganography settings
+        // Conversion settings
         Row(
             modifier = modifier.fillMaxWidth(0.9f)
         ) {
             Icon(
                 imageVector = Icons.Outlined.Key,
-                contentDescription = "Steganography settings"
+                contentDescription = "Conversion settings"
             )
 
             Spacer(modifier = modifier.width(16.dp))
 
             Column {
                 Text(
-                    text = "Steganography",
+                    text = "Conversion",
                     fontSize = 18.sp,
                     fontWeight = FontWeight.Bold
                 )
@@ -275,6 +275,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
 
         Spacer(modifier = modifier.height(16.dp))
 
+        // Steganography settings
         Row(
             modifier = modifier.fillMaxWidth(0.9f)
         ) {
@@ -286,6 +287,12 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
             Spacer(modifier = modifier.width(16.dp))
 
             Column {
+                Text(
+                    text = "Steganography",
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold
+                )
+
                 Text(text = "Select how to encode the secret message into a cover text.")
 
                 Spacer(modifier = modifier.height(16.dp))

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
@@ -75,6 +75,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
     var isInMemory by rememberSaveable { mutableStateOf(LlamaCpp.isInMemory()) }
     var selectedConversionMode by rememberSaveable { mutableStateOf(Settings.conversionMode) }
     var systemPrompt by rememberSaveable { mutableStateOf(Settings.systemPrompt) }
+    var selectedNumberOfMessages by rememberSaveable { mutableIntStateOf(Settings.numberOfMessages) }
     var selectedSteganographyMode by rememberSaveable { mutableStateOf(Settings.steganographyMode) }
     var selectedTemperature by rememberSaveable { mutableFloatStateOf(Settings.temperature) }
     var selectedBlockSize by rememberSaveable { mutableIntStateOf(Settings.blockSize) }
@@ -345,6 +346,38 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                 ) {
                     Text(text = "Save")
                 }
+
+                Spacer(modifier = modifier.height(16.dp))
+
+                // Select number of messages
+                Text(text = "Select the number of prior messages to use as context.")
+
+                Spacer(modifier = modifier.height(16.dp))
+
+                Slider(
+                    value = selectedNumberOfMessages.toFloat(),
+                    onValueChange = {
+                        // Update state variable
+                        selectedNumberOfMessages = it.toInt()
+
+                        // Update DataStore
+                        Settings.numberOfMessages = it.toInt()
+                        coroutineScope.launch { HiPSDataStore.writeSettings() }
+                    },
+                    valueRange = 0f..10f,
+                    steps = 9
+                )
+
+                Spacer(modifier = modifier.height(8.dp))
+
+                Text(
+                    text = when (selectedNumberOfMessages) {
+                        0 -> "All messages"
+                        1 -> "1 message"
+                        else -> "$selectedNumberOfMessages messages"
+                    },
+                    modifier = modifier.align(Alignment.CenterHorizontally)
+                )
 
                 Spacer(modifier = modifier.height(16.dp))
 

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
@@ -162,7 +162,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
         Row {
             Button(
                 onClick = {
-                    if(!isDownloaded) {
+                    if (!isDownloaded) {
                         LLM.download(currentLocalContext)
                         isDownloaded = true
                     }

--- a/app/src/main/java/org/vonderheidt/hips/utils/Format.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Format.kt
@@ -23,8 +23,14 @@ object Format {
      *
      * @param bitString A bit string.
      * @return The ByteArray.
+     * @throws IllegalArgumentException If `bitString` contains anything other than 1s and 0s.
      */
     fun asByteArray(bitString: String): ByteArray {
+        // Check integrity of the bit string
+        if (!isBitString(bitString)) {
+            throw IllegalArgumentException("Bit string can only contain 0 and 1")
+        }
+
         // Don't assert string length to be a multiple of 8, causes error in Huffman encoding with 3 bits/token
         val byteArray = ByteArray(size = bitString.length / 8) { index ->
             val byteString = bitString.substring(startIndex = index * 8, endIndex = (index + 1) * 8)
@@ -34,5 +40,15 @@ object Format {
         }
 
         return byteArray
+    }
+
+    /**
+     * Function to check integrity of a bit string, i.e. if it only contains 1s and 0s.
+     *
+     * @param bitString A bit string.
+     * @return Boolean that is true if `bitString` only contains 1s and 0s, false otherwise.
+     */
+    private fun isBitString(bitString: String): Boolean {
+        return bitString.all { bit -> bit == '0' || bit == '1' }
     }
 }

--- a/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
@@ -41,7 +41,7 @@ object LlamaCpp {
 
         // Otherwise, load the LLM and store its memory address
         // Synchronized allows only one thread to execute the code inside {...}, so other threads can't load the LLM simultaneously
-        synchronized(this) {
+        synchronized(lock = this) {
             if (!isInMemory()) {
                 model = loadModel()
                 ctx = loadCtx()
@@ -59,7 +59,7 @@ object LlamaCpp {
             return
         }
 
-        synchronized(this) {
+        synchronized(lock = this) {
             if (isInMemory()) {
                 unloadSmpl()
                 smpl = 0L
@@ -85,7 +85,7 @@ object LlamaCpp {
             return
         }
 
-        synchronized(this) {
+        synchronized(lock = this) {
             if (ctx != 0L) {
                 unloadCtx()
                 ctx = 0L

--- a/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
@@ -213,7 +213,7 @@ object LlamaCpp {
     external fun getLogits(tokens: IntArray, ctx: Long = this.ctx): Array<FloatArray>
 
     /**
-     * Wrapper for the `llama_token_is_eog` and `llama_token_is_control` functions of llama.cpp. Checks if a token is a special token.
+     * Wrapper for the `llama_vocab_is_eog` and `llama_vocab_is_control` functions of llama.cpp. Checks if a token is a special token.
      *
      * @param token Token ID to check.
      * @param model Memory address of the LLM.

--- a/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
@@ -216,10 +216,10 @@ object LlamaCpp {
      * Wrapper for the `llama_token_is_eog` and `llama_token_is_control` functions of llama.cpp. Checks if a token is a special token.
      *
      * @param token Token ID to check.
-     * @param ctx Memory address of the context.
-     * @return Boolean that is true if the token special, false otherwise.
+     * @param model Memory address of the LLM.
+     * @return Boolean that is true if the token is special, false otherwise.
      */
-    private external fun isSpecial(token: Int, ctx: Long = this.ctx): Boolean
+    private external fun isSpecial(token: Int, model: Long = this.model): Boolean
 
     /**
      * Wrapper for the `llama_sampler_sample` function of llama.cpp. Samples the next token based on the last one.

--- a/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
@@ -229,4 +229,19 @@ object LlamaCpp {
      * @return ID of the next token.
      */
     external fun sample(lastToken: Int, ctx: Long = this.ctx, smpl: Long = this.smpl): Int
+
+    /**
+     * Wrapper for the `llama_chat_apply_template` function of llama.cpp. Formats a message as a llama.cpp chat message so that it can be added to a chat.
+     * This involves the following steps:
+     * 1. Prepend a special token for the desired role (`system`, `user` or `assistant`).
+     * 2. Append a special token to signal the end of the message.
+     * 3. If the message is the last in the chat, append the special token for the `assistant` role to signal the LLM that it should generate the next message.
+     *
+     * @param role Role the new chat message should be sent as (`system`, `user` or `assistant`).
+     * @param content Content of the new chat message.
+     * @param appendAssistant Boolean that is true if the special token for the `assistant` role is to be appended at the end, false otherwise.
+     * @param model Memory address of the LLM.
+     * @return The message formatted as llama.cpp chat message.
+     */
+    private external fun addMessage(role: String, content: String, appendAssistant: Boolean, model: Long = this.model): String
 }

--- a/app/src/main/java/org/vonderheidt/hips/utils/Role.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Role.kt
@@ -1,0 +1,10 @@
+package org.vonderheidt.hips.utils
+
+/**
+ * Class that defines all roles for llama.cpp chat messages.
+ */
+sealed class Role(val name: String) {
+    data object Assistant: Role("assistant")
+    data object System: Role("system")
+    data object User: Role("user")
+}


### PR DESCRIPTION
Implemented steganography on conversation screen:
- Added system prompt to settings screen
- Added number of prior messages to use as steganography context to settings screen
- Added function to assign roles `system`, `user` and `assistant` to messages so that LLM talks to itself without knowing it
- Added option to send arbitrary plain text messages in between cover texts
- Refined behaviour of send and decode buttons and added loading animations
- Changed colours of messages for better readability
- Added loading LLM on startup and checks to see if LLM is loaded for stability
- Various minor cleanups