### PR TITLE
Implement arithmetic coding

### DIFF
--- a/app/src/main/cpp/hips.cpp
+++ b/app/src/main/cpp/hips.cpp
@@ -298,6 +298,31 @@ extern "C" JNIEXPORT jboolean JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_i
 }
 
 /**
+ * Function to check if a token is an end-of-generation (eog) token.
+ *
+ * @param env The JNI environment.
+ * @param thiz Java object this function was called with.
+ * @param token Token ID to check.
+ * @param jModel Memory address of the LLM.
+ * @return Boolean that is true if the token is an eog token, false otherwise.
+ */
+extern "C" JNIEXPORT jboolean JNICALL Java_org_vonderheidt_hips_utils_LlamaCpp_isEndOfGeneration(JNIEnv* /* env */, jobject /* thiz */, jint token, jlong jModel) {
+    // Cast memory address of LLM from Java long to C++ pointer
+    auto cppModel = reinterpret_cast<llama_model*>(jModel);
+
+    // Check if token is eog token
+    // Token ID doesn't need casting because jint and llama_token are both just int32_t
+    const llama_vocab* vocab = llama_model_get_vocab(cppModel);
+    bool cppIsEog = llama_vocab_is_eog(vocab, token);
+
+    // Cast boolean to return it
+    // static_cast because casting booleans is type safe, unlike reinterpret_cast for casting C++ pointers to Java long
+    auto jIsEog = static_cast<jboolean>(cppIsEog);
+
+    return jIsEog;
+}
+
+/**
  * Function to calculate the logit matrix (i.e. predictions for every token in the prompt).
  *
  * Only the last row of the `n_tokens` x `n_vocab` matrix is actually needed as it contains the logits corresponding to the last token of the prompt.

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
@@ -90,6 +90,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
     var selectedSteganographyMode by rememberSaveable { mutableStateOf(Settings.steganographyMode) }
     var selectedTemperature by rememberSaveable { mutableFloatStateOf(Settings.temperature) }
     var selectedTopK by rememberSaveable { mutableIntStateOf(Settings.topK) }
+    var selectedPrecision by remember { mutableIntStateOf(Settings.precision) }
     var selectedBlockSize by rememberSaveable { mutableIntStateOf(Settings.blockSize) }
     var selectedBitsPerToken by rememberSaveable { mutableIntStateOf(Settings.bitsPerToken) }
     val selectedResetModes = remember { mutableStateListOf(0, 1) }
@@ -503,6 +504,35 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                                 text = "${(selectedTopK.toFloat() / LlamaCpp.getVocabSize() * 100).toInt()}% of the vocabulary",
                                 modifier = modifier.align(Alignment.CenterHorizontally)
                             )
+
+                            Spacer(modifier = modifier.height(16.dp))
+
+                            // Precision
+                            Text(text = "Set the precision for token sampling.")
+
+                            Spacer(modifier = modifier.height(16.dp))
+
+                            // Again, do int conversion here as slider only allows floats
+                            Slider(
+                                value = selectedPrecision.toFloat(),
+                                onValueChange = {
+                                    // Update state variable
+                                    selectedPrecision = it.toInt()
+
+                                    // Update DataStore
+                                    Settings.precision = it.toInt()
+                                    coroutineScope.launch { HiPSDataStore.writeSettings() }
+                                },
+                                valueRange = 0f..32f,
+                                steps = 31
+                            )
+
+                            Spacer(modifier = modifier.height(8.dp))
+
+                            Text(
+                                text = "$selectedPrecision " + if (selectedPrecision == 1) "bit" else "bits",
+                                modifier = modifier.align(Alignment.CenterHorizontally)
+                            )
                         }
                         else {
                             Text(
@@ -653,6 +683,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                             selectedNumberOfMessages = Settings.numberOfMessages
                             selectedSteganographyMode = Settings.steganographyMode
                             selectedTemperature = Settings.temperature
+                            selectedPrecision = Settings.precision
                             selectedTopK = Settings.topK
                             selectedBlockSize = Settings.blockSize
                             selectedBitsPerToken = Settings.bitsPerToken

--- a/app/src/main/java/org/vonderheidt/hips/utils/Arithmetic.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Arithmetic.kt
@@ -158,6 +158,7 @@ object Arithmetic {
                 }.toMutableList()
 
                 // Stegasuras: "Get selected index based on binary fraction from message bits"
+                // Process cipher bits in portions of size precision
                 // Unlike Python, Kotlin doesn't handle "cipherBitString.substring(startIndex = i, endIndex = i + precision)" gracefully if i + precision is too large
                 var messageBits = if (i + precision < cipherBitString.length) {
                     cipherBitString.substring(startIndex = i, endIndex = i + precision)
@@ -166,6 +167,7 @@ object Arithmetic {
                     cipherBitString.substring(startIndex = i)
                 }
 
+                // Append 0s to last cipher bits to make last portion of size precision as well
                 if (i + precision > cipherBitString.length) {
                     messageBits += "0".repeat(i + precision - cipherBitString.length)
                 }

--- a/app/src/main/java/org/vonderheidt/hips/utils/Arithmetic.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Arithmetic.kt
@@ -172,6 +172,9 @@ object Arithmetic {
                     messageBits += "0".repeat(i + precision - cipherBitString.length)
                 }
 
+                // Convert portion of cipher bits to integer for comparison with cumulated probabilities
+                // Find position of first token with cumulated probability larger than this integer, i.e. find relevant sub-interval of current interval
+                // => sampledToken is already determined here, next steps only calculate new interval
                 val messageIdx = Format.asInteger(messageBits)                                 // Stegasuras would reverse messageBits, shouldn't be necessary here
                 val selection = cumProbs.indexOfFirst { it.second > messageIdx }
 
@@ -196,7 +199,7 @@ object Arithmetic {
                 curInterval[0] = Format.asInteger(newIntBottomBits)                            // Again, reversing shouldn't be necessary here
                 curInterval[1] = Format.asInteger(newIntTopBits) + 1                           // Stegasuras: "+1 here because upper bound is exclusive"
 
-                // Sample token
+                // Sample token as determined above
                 sampledToken = cumProbs[selection].first
 
                 // </Logic specific to arithmetic coding>

--- a/app/src/main/java/org/vonderheidt/hips/utils/Arithmetic.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Arithmetic.kt
@@ -318,7 +318,14 @@ object Arithmetic {
             if (overfillIndex.isNotEmpty()) {
                 cumProbs = cumProbs.dropLast(overfillIndex.size).toMutableList()
                 // Reassignment of k is new in decode, but not used here as possible BPE errors are ignored below
-                // Would be "k = overfillIndex.size"
+                // Logic of Stegasuras is somewhat inverted again
+                // Stegasuras: overfill_index[0] = Index of first token with cumulated probability > cur_int_range
+                //             = Number of tokens with cumulated probability <= cur_int_range
+                //             = Size of cum_probs after it was overwritten there
+                // HiPS: overfillIndex = List of tokens with cumulated probability > curIntRange
+                //       != Size of cumProbs after it was overwritten here
+                // Now "if (rank >= k) { ... }" from BPE fixes below makes sense
+                // k = cumProbs.size
             }
 
             // Stegasuras: "Add any mass to the top if removing/rounding causes the total prob to be too small"

--- a/app/src/main/java/org/vonderheidt/hips/utils/Arithmetic.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Arithmetic.kt
@@ -1,7 +1,9 @@
 package org.vonderheidt.hips.utils
 
-import kotlinx.coroutines.delay
 import org.vonderheidt.hips.data.Settings
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
 
 /**
  * Object (i.e. singleton class) that represents steganography using arithmetic encoding.
@@ -10,14 +12,207 @@ object Arithmetic {
     /**
      * Function to encode (the encrypted binary representation of) the secret message into a cover text using arithmetic encoding.
      *
-     * Corresponds to Stegasuras method `encode_arithmetic` in `arithmetic.py`.
+     * Corresponds to Stegasuras method `encode_arithmetic` in `arithmetic.py`. Parameter `finish_sent` was removed (<=> is now hard coded to true).
+     *
+     * @param context The context to encode the secret message with.
+     * @param cipherBits The encrypted binary representation of the secret message.
+     * @param temperature The temperature parameter for token sampling. Determined by Settings object.
+     * @param topK Number of most likely tokens to consider. Must be less than or equal to the vocabulary size `n_vocab` of the LLM. Determined by Settings object.
+     * @param precision Number of bits to encode the top k tokens with. Determined by Settings object.
+     * @return A cover text containing the secret message.
      */
-    suspend fun encode(context: String, cipherBits: ByteArray, temperature: Float = Settings.temperature): String {
-        // Wait 5 seconds
-        delay(5000)
+    fun encode(context: String, cipherBits: ByteArray, temperature: Float = Settings.temperature, topK: Int = Settings.topK, precision: Int = Settings.precision): String {
+        // Tokenize context
+        var contextTokens = LlamaCpp.tokenize(context)
 
-        // Return placeholder
-        val coverText = ""
+        // Convert cipher bits to bit string
+        val cipherBitString = Format.asBitString(cipherBits)
+
+        // Initialize array to store cover text tokens
+        var coverTextTokens = intArrayOf()
+
+        // <Logic specific to arithmetic coding>
+
+        // Stegasuras paper says that binary conversion happens with empty context, but code actually uses a single end-of-generation (eog) token as context
+        // Similarly, an eog token also is appended to the secret message (passed via cover text parameter)
+        // llama.cpp crashes with empty context anyway
+        // UI doesn't allow empty context for steganography, so no collision possible when calling Arithmetic.{decode,encode} for binary conversion
+        if (contextTokens.isEmpty()) {
+            contextTokens += LlamaCpp.getEndOfGeneration()
+            coverTextTokens += LlamaCpp.getEndOfGeneration()
+        }
+
+        // Define initial interval as [0, maxVal) = [0, 2^precision)
+        val maxVal = 1 shl precision
+        val curInterval = intArrayOf(0, maxVal) // Stegasuras: "Bottom inclusive, top exclusive"
+
+        // </Logic specific to arithmetic coding>
+
+        // Initialize variables and flags for loop
+        var i = 0
+        var isLastSentenceFinished = false
+
+        var isFirstRun = true                   // llama.cpp batch needs to store context tokens in first run, but only last sampled token in subsequent runs
+        var sampledToken = -1                   // Will always be overwritten with last cover text token
+
+        // Sample tokens until all bits of secret message are encoded and last sentence is finished
+        while (i < cipherBitString.length || !isLastSentenceFinished) {
+            // Arithmetic sampling to encode bits of secret message into tokens
+            if (i < cipherBitString.length) {
+                // Call llama.cpp to calculate the logit matrix similar to https://github.com/ggerganov/llama.cpp/blob/master/examples/simple/simple.cpp:
+                // Needs only next tokens to be processed to store in a batch, i.e. contextTokens in first run and last sampled token in subsequent runs, rest is managed internally in ctx
+                // Only last row of logit matrix is needed as it contains logits corresponding to last token of the prompt
+                val logits = LlamaCpp.getLogits(if (isFirstRun) contextTokens else intArrayOf(sampledToken)).last()
+
+                // Suppress special tokens to avoid early termination before all bits of secret message are encoded
+                LlamaCpp.suppressSpecialTokens(logits)
+
+                // <Logic specific to arithmetic coding>
+
+                // Normalize logits to probabilities
+                val probs = Statistics.softmax(logits)
+
+                // Scale probabilities with 1/temperature and sort descending
+                val probsTemp = probs
+                    .mapIndexed { token, probability -> token to probability/temperature }
+                    .sortedByDescending { it.second }
+
+                // Stegasuras: "Cut off low probabilities that would be rounded to 0"
+                // curThreshold needs to be float as it will be compared to probabilities, float division happens implicitly in Python but explicitly in Kotlin
+                val curIntRange = curInterval[1] - curInterval[0]
+                val curThreshold = 1.0f / curIntRange
+
+                // Invert logic of Stegasuras:
+                // Stegasuras: Drop all tokens with probability < curThreshold
+                // <=> HiPS: Keep all tokens with probability >= curThreshold
+
+                // Minimum ensures that k doesn't exceed topK
+                // Maximum ensures that at least the tokens with the top 2 probabilities are considered
+                val k = min(
+                    max(
+                        2,
+                        probsTemp.filter { it.second >= curThreshold }.size
+                    ),
+                    topK
+                )
+
+                // Keep tokens with top k (!= topK) probabilities
+                // Stegasuras would use variable name probsTempInt here already, but requires overwriting one data type with another (List<Pair<Int, Float>> vs List<Pair<Int, Int>>)
+                // Possible in Python, but not in Kotlin
+                // Use topProbsTemp for now to be similar to decode, probsTempInt only after rounding probabilities from float to int below
+                var topProbsTemp = probsTemp.take(k)
+
+                // Stegasuras: "Rescale to correct range"
+                // Top k probabilities sum up to something in [0,1), rescale to [0, maxVal)
+                var topProbsTempSum = 0.0f
+
+                for ((token, probability) in topProbsTemp) {
+                    topProbsTempSum += probability
+                }
+
+                topProbsTemp = topProbsTemp.map {
+                    Pair(it.first, it.second / topProbsTempSum * curIntRange)
+                }
+
+                // Stegasuras: "Round probabilities to integers given precision"
+                // Variable name probsTempInt is appropriate now
+                val probsTempInt = topProbsTemp.map {
+                    Pair(it.first, it.second.roundToInt())
+                }
+
+                // Replace probability with cumulated probability
+                // Probabilities that would round to 0 were cut off earlier, so all at least round to 1, no collisions possible
+                var cumProbs = mutableListOf<Pair<Int, Int>>()
+                var cumulatedProbability = 0
+
+                for ((token, probability) in probsTempInt) {
+                    cumulatedProbability += probability
+                    cumProbs.add(Pair(token, cumulatedProbability))
+                }
+
+                // Stegasuras: "Remove any elements from the bottom if rounding caused the total prob to be too large"
+                // Remove tokens with low probabilities if their cumulated probability is too large
+                val overfillIndex = cumProbs.filter { it.second > curIntRange }
+
+                if (overfillIndex.isNotEmpty()) {
+                    cumProbs = cumProbs.dropLast(overfillIndex.size).toMutableList()
+                }
+
+                // Stegasuras: "Add any mass to the top if removing/rounding causes the total prob to be too small"
+                // Removing tokens might have created a gap at the top, i.e. a sub-interval between cumulated probability of last token and top of current interval, that doesn't correspond to any token
+                // Arithmetic coding only works when current interval is exactly filled, so close the gap by shifting all cumulated probabilities up by its size
+                // Equivalent to first token having larger probability, shifting cumulated probabilities of all subsequent tokens
+                cumProbs = cumProbs.map {
+                    Pair(it.first, it.second + curIntRange - cumProbs.last().second)
+                }.toMutableList()
+
+                // Stegasuras: "Convert to position in range"
+                // Shifts all cumulated probabilities up again by bottom of current interval
+                cumProbs = cumProbs.map {
+                    Pair(it.first, it.second + curInterval[0])
+                }.toMutableList()
+
+                // Stegasuras: "Get selected index based on binary fraction from message bits"
+                // Unlike Python, Kotlin doesn't handle "cipherBitString.substring(startIndex = i, endIndex = i + precision)" gracefully if i + precision is too large
+                var messageBits = if (i + precision < cipherBitString.length) {
+                    cipherBitString.substring(startIndex = i, endIndex = i + precision)
+                }
+                else {
+                    cipherBitString.substring(startIndex = i)
+                }
+
+                if (i + precision > cipherBitString.length) {
+                    messageBits += "0".repeat(i + precision - cipherBitString.length)
+                }
+
+                val messageIdx = Format.asInteger(messageBits)                                 // Stegasuras would reverse messageBits, shouldn't be necessary here
+                val selection = cumProbs.indexOfFirst { it.second > messageIdx }
+
+                // Stegasuras: "Calculate new range as ints"
+                val newIntBottom = if (selection > 0) cumProbs[selection-1].second else curInterval[0]
+                val newIntTop = cumProbs[selection].second
+
+                // Stegasuras: "Convert range to bits"
+                val newIntBottomBitsInc = Format.asBitString(newIntBottom, precision)          // Again, reversing shouldn't be necessary here
+                val newIntTopBitsInc = Format.asBitString(newIntTop - 1, precision)     // Stegasuras: "-1 here because upper bound is exclusive"
+
+                // Stegasuras: "Consume most significant bits which are now fixed and update interval"
+                // Arithmetic coding encodes data into a number by iteratively narrowing initial interval defined earlier
+                // Therefore most significant bits are fixed first (~ numSameFromBeg), determining the order of magnitude of the number, less significant bits are fixed later
+                val numBitsEncoded = numSameFromBeg(newIntBottomBitsInc, newIntTopBitsInc)
+                i += numBitsEncoded
+
+                // New interval is determined by setting unfixed bits to 0 for bottom end, to 1 for top end
+                val newIntBottomBits = newIntBottomBitsInc.substring(startIndex = numBitsEncoded) + "0".repeat(numBitsEncoded)
+                val newIntTopBits = newIntTopBitsInc.substring(startIndex = numBitsEncoded) + "1".repeat(numBitsEncoded)
+
+                curInterval[0] = Format.asInteger(newIntBottomBits)                            // Again, reversing shouldn't be necessary here
+                curInterval[1] = Format.asInteger(newIntTopBits) + 1                           // Stegasuras: "+1 here because upper bound is exclusive"
+
+                // Sample token
+                sampledToken = cumProbs[selection].first
+
+                // </Logic specific to arithmetic coding>
+
+                // Update flag
+                isFirstRun = false
+            }
+            // Greedy sampling to pick most likely token until last sentence is finished
+            else {
+                // llama.cpp greedy sampler is used for efficiency instead of manually sorting logits descending and picking the first one
+                // Input is only last sampled token similar to else case of getLogits input above, as greedy sampling only over gets called after arithmetic sampling
+                sampledToken = LlamaCpp.sample(sampledToken)
+
+                // Update flag
+                isLastSentenceFinished = LlamaCpp.isEndOfSentence(sampledToken)
+            }
+
+            // Append last sampled token to cover text tokens
+            coverTextTokens += sampledToken
+        }
+
+        // Detokenize cover text tokens into cover text to return it
+        val coverText = LlamaCpp.detokenize(coverTextTokens)
 
         return coverText
     }
@@ -26,14 +221,193 @@ object Arithmetic {
      * Function to decode a cover text into (the encrypted binary representation of) the secret message using arithmetic decoding.
      *
      * Corresponds to Stegasuras method `decode_arithmetic` in `arithmetic.py`.
+     *
+     * @param context The context to decode the cover text with.
+     * @param coverText The cover text containing a secret message.
+     * @param temperature The temperature parameter for token sampling. Determined by Settings object.
+     * @param topK Number of most likely tokens to consider. Must be less than or equal to the vocabulary size `n_vocab` of the LLM. Determined by Settings object.
+     * @param precision Number of bits to encode the top k tokens with. Determined by Settings object.
+     * @return The encrypted binary representation of the secret message.
      */
-    suspend fun decode(context: String, coverText: String, temperature: Float = Settings.temperature): ByteArray {
-        // Wait 5 seconds
-        delay(5000)
+    fun decode(context: String, coverText: String, temperature: Float = Settings.temperature, topK: Int = Settings.topK, precision: Int = Settings.precision): ByteArray {
+        // Tokenize context and cover text
+        var contextTokens = LlamaCpp.tokenize(context)
+        var coverTextTokens = LlamaCpp.tokenize(coverText)
 
-        // Return placeholder
-        val cipherBits = ByteArray(size = 0)
+        // <Logic specific to arithmetic coding>
+
+        // Similar to encode
+        if (contextTokens.isEmpty()) {
+            contextTokens += LlamaCpp.getEndOfGeneration()
+            coverTextTokens += LlamaCpp.getEndOfGeneration()
+        }
+
+        val maxVal = 1 shl precision
+        val curInterval = intArrayOf(0, maxVal)
+
+        // </Logic specific to arithmetic coding>
+
+        // Initialize string to store cipher bits
+        var cipherBitString = ""
+
+        // Initialize variables and flags for loop
+        var i = 0
+
+        var isFirstRun = true
+        var coverTextToken = -1
+
+        // Decode every cover text token
+        while (i < coverTextTokens.size) {
+            // Calculate the logit matrix again initially from context tokens, then from last cover text token, and get last row
+            val logits = LlamaCpp.getLogits(if (isFirstRun) contextTokens else intArrayOf(coverTextToken)).last()
+
+            // Suppress special tokens
+            LlamaCpp.suppressSpecialTokens(logits)
+
+            // <Logic specific to arithmetic coding>
+
+            // Similar to encode
+            val probs = Statistics.softmax(logits)
+
+            val probsTemp = probs
+                .mapIndexed { token, probability -> token to probability/temperature }
+                .sortedByDescending { it.second }
+
+            // Stegasuras: "Cut off low probabilities that would be rounded to 0"
+            val curIntRange = curInterval[1] - curInterval[0]
+            val curThreshold = 1.0f / curIntRange
+
+            val k = min(
+                max(
+                    2,
+                    probsTemp.filter { it.second >= curThreshold }.size
+                ),
+                topK
+            )
+
+            // Don't reassign "probsTemp = probsTemp.take(k)" but introduce new variable topProbsTemp as decode needs probsTemp again later
+            var topProbsTemp = probsTemp.take(k)
+
+            // Stegasuras: "Rescale to correct range"
+            var topProbsTempSum = 0.0f
+
+            for ((token, probability) in topProbsTemp) {
+                topProbsTempSum += probability
+            }
+
+            topProbsTemp = topProbsTemp.map {
+                Pair(it.first, it.second / topProbsTempSum * curIntRange)
+            }
+
+            // Stegasuras: "Round probabilities to integers given precision"
+            val probsTempInt = topProbsTemp.map {
+                Pair(it.first, it.second.roundToInt())
+            }
+
+            var cumProbs = mutableListOf<Pair<Int, Int>>()
+            var cumulatedProbability = 0
+
+            for ((token, probability) in probsTempInt) {
+                cumulatedProbability += probability
+                cumProbs.add(Pair(token, cumulatedProbability))
+            }
+
+            // Stegasuras: "Remove any elements from the bottom if rounding caused the total prob to be too large"
+            val overfillIndex = cumProbs.filter { it.second > curIntRange }
+
+            if (overfillIndex.isNotEmpty()) {
+                cumProbs = cumProbs.dropLast(overfillIndex.size).toMutableList()
+                // Reassignment of k is new in decode, but not used here as possible BPE errors are ignored below
+                // Would be "k = overfillIndex.size"
+            }
+
+            // Stegasuras: "Add any mass to the top if removing/rounding causes the total prob to be too small"
+            cumProbs = cumProbs.map {
+                Pair(it.first, it.second + curIntRange - cumProbs.last().second)
+            }.toMutableList()
+
+            // Stegasuras: "Convert to position in range"
+            cumProbs = cumProbs.map {
+                Pair(it.first, it.second + curInterval[0])
+            }.toMutableList()
+
+            // Stegasuras: n/a
+            // Skip fix of BPE errors and therefore rank variable
+            // TODO
+            //  Only steganography encoding/decoding works, binary conversion still crashes
+            //  LLM would have to predict tokens in secret message (passed via cover text parameter) to convert them into bits via Arithmetic.decode
+            //  Not obvious why it should do that when context is only an eog token
+            //  Why is probsTemp (equivalent to indices in Stegasuras), containing all tokens, used here when cumProbs, containing only top k tokens, is queried later?
+            //  Next step causes IndexOutOfBoundsException in first iteration of binary conversion
+            //  Can happen during any later iteration as well if user input is unpredictable for LLM
+            val selection = probsTemp.indexOfFirst { it.first == coverTextTokens[i] }
+
+            // Stegasuras: "Calculate new range as ints"
+            val newIntBottom = if (selection > 0) cumProbs[selection-1].second else curInterval[0]
+            val newIntTop = cumProbs[selection].second
+
+            // Stegasuras: "Convert range to bits"
+            val newIntBottomBitsInc = Format.asBitString(newIntBottom, precision)
+            val newIntTopBitsInc = Format.asBitString(newIntTop - 1, precision)
+
+            // Stegasuras: "Emit most significant bits which are now fixed and update interval"
+            // Inline += operation to eliminate newBits variable
+            val numBitsEncoded = numSameFromBeg(newIntBottomBitsInc, newIntTopBitsInc)
+
+            cipherBitString += if (i == coverTextTokens.size - 1) {
+                newIntBottomBitsInc
+            }
+            else {
+                newIntTopBitsInc.substring(startIndex = 0, endIndex = numBitsEncoded)
+            }
+
+            val newIntBottomBits = newIntBottomBitsInc.substring(startIndex = numBitsEncoded) + "0".repeat(numBitsEncoded)
+            val newIntTopBits = newIntTopBitsInc.substring(startIndex = numBitsEncoded) + "1".repeat(numBitsEncoded)
+
+            curInterval[0] = Format.asInteger(newIntBottomBits)
+            curInterval[1] = Format.asInteger(newIntTopBits) + 1
+
+            // </Logic specific to arithmetic coding>
+
+            // Update loop variables and flags
+            coverTextToken = coverTextTokens[i]
+            isFirstRun = false
+
+            i++
+        }
+
+        // Create ByteArray from bit string to return cipher bits
+        val cipherBits = Format.asByteArray(cipherBitString)
 
         return cipherBits
+    }
+
+    /**
+     * Function to determine number of bits that are the same from the beginning of two bit strings.
+     *
+     * Corresponds to Stegasuras method `num_same_from_beg` in `utils.py`. Parameter `bits1` was renamed to `bitString1`, `bits2` to `bitString2`.
+     *
+     * @param bitString1 A bit string.
+     * @param bitString2 Another bit string.
+     * @return Number of bits that are the same from the beginning of the bit strings.
+     * @throws IllegalArgumentException If the two bit strings are of different length.
+     */
+    private fun numSameFromBeg(bitString1: String, bitString2: String): Int {
+        // Only edge case covered in Stegasuras
+        if (bitString1.length != bitString2.length) {
+            throw IllegalArgumentException("The bit strings are of different length")
+        }
+
+        var numSameFromBeg = 0
+
+        for (i in bitString1.indices) {
+            if (bitString1[i] != bitString2[i]) {
+                break
+            }
+
+            numSameFromBeg++
+        }
+
+        return numSameFromBeg
     }
 }

--- a/app/src/main/java/org/vonderheidt/hips/utils/Arithmetic.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Arithmetic.kt
@@ -88,6 +88,11 @@ object Arithmetic {
 
                 // Minimum ensures that k doesn't exceed topK
                 // Maximum ensures that at least the tokens with the top 2 probabilities are considered
+                // => Maximum is relevant if next token is practically certain (e.g. "Albert Einstein was a renowned theoretical" will be continued with " physicist" with > 99.5% probability)
+                //    Probability of second most likely token will already be rounded to 0
+                // => Loop can go through runs that don't encode any information (i.e. secret message bits) because a token is certain, but next token won't be certain and will encode information again
+                //    Not possible with Huffman, where every token encodes bitsPerToken bits of information
+                // => Matches entropy: Events that are certain don't contain any information (<=> Events that are very uncertain contain a lot of information)
                 val k = min(
                     max(
                         2,

--- a/app/src/main/java/org/vonderheidt/hips/utils/Arithmetic.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Arithmetic.kt
@@ -179,12 +179,15 @@ object Arithmetic {
                 val selection = cumProbs.indexOfFirst { it.second > messageIdx }
 
                 // Stegasuras: "Calculate new range as ints"
+                // Calculate bottom and top of relevant sub-interval for next iteration
+                // New bottom (inclusive) is top of preceding sub-interval (exclusive there) if relevant one is not the first one, old bottom otherwise
+                // New top (exclusive) is top of relevant sub-interval
                 val newIntBottom = if (selection > 0) cumProbs[selection-1].second else curInterval[0]
                 val newIntTop = cumProbs[selection].second
 
                 // Stegasuras: "Convert range to bits"
                 val newIntBottomBitsInc = Format.asBitString(newIntBottom, precision)          // Again, reversing shouldn't be necessary here
-                val newIntTopBitsInc = Format.asBitString(newIntTop - 1, precision)     // Stegasuras: "-1 here because upper bound is exclusive"
+                val newIntTopBitsInc = Format.asBitString(newIntTop - 1, precision)     // Stegasuras: "-1 here because upper bound is exclusive" (i.e. newIntTopBitsInc is inclusive)
 
                 // Stegasuras: "Consume most significant bits which are now fixed and update interval"
                 // Arithmetic coding encodes data into a number by iteratively narrowing initial interval defined earlier
@@ -193,6 +196,8 @@ object Arithmetic {
                 i += numBitsEncoded
 
                 // New interval is determined by setting unfixed bits to 0 for bottom end, to 1 for top end
+                // Interval boundaries can jump around because first numBitsEncoded bits are already processed and therefore cut off
+                // Next portion of cipher bits in general doesn't narrow the interval
                 val newIntBottomBits = newIntBottomBitsInc.substring(startIndex = numBitsEncoded) + "0".repeat(numBitsEncoded)
                 val newIntTopBits = newIntTopBitsInc.substring(startIndex = numBitsEncoded) + "1".repeat(numBitsEncoded)
 

--- a/app/src/main/java/org/vonderheidt/hips/utils/Format.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Format.kt
@@ -43,6 +43,43 @@ object Format {
     }
 
     /**
+     * Function to format an integer as a bit string of desired length. Pads the bit string with leading 0s if needed.
+     *
+     * Corresponds to Stegasuras method `int2bits` in `utils.py`. Parameter `inp` was renamed to `integer`, `num_bits` to `numberOfBits`.
+     *
+     * @param integer An integer.
+     * @param numberOfBits The desired length of the bit string.
+     * @return The bit string.
+     */
+    fun asBitString(integer: Int, numberOfBits: Int): String {
+        // Only edge case covered in Stegasuras
+        if (numberOfBits == 0) {
+            return ""
+        }
+
+        // Convert integer to bit string of minimum necessary length and pad it to desired length
+        val bitString = Integer
+            .toBinaryString(integer)
+            .padStart(numberOfBits, '0')
+
+        return bitString
+    }
+
+    /**
+     * Function to reverse formatting of an integer as a bit string (i.e. to reverse `Format.asBitString(Int, Int)`).
+     *
+     * Corresponds to Stegasuras method `bits2int` in `utils.py`. Parameter `bits` was renamed to `bitString`.
+     *
+     * @param bitString A bit string containing an integer.
+     * @return The integer.
+     */
+    fun asInteger(bitString: String): Int {
+        val integer = bitString.toInt(radix = 2)
+
+        return integer
+    }
+
+    /**
      * Function to check integrity of a bit string, i.e. if it only contains 1s and 0s.
      *
      * @param bitString A bit string.

--- a/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
@@ -277,6 +277,15 @@ object LlamaCpp {
     private external fun isSpecial(token: Int, model: Long = this.model): Boolean
 
     /**
+     * Wrapper for the `llama_vocab_is_eog` function of llama.cpp. Checks if a token is an end-of-generation (eog) token.
+     *
+     * @param token Token ID to check.
+     * @param model Memory address of the LLM.
+     * @return Boolean that is true if the token is an eog token, false otherwise.
+     */
+    private external fun isEndOfGeneration(token: Int, model: Long = this.model): Boolean
+
+    /**
      * Wrapper for the `llama_sampler_sample` function of llama.cpp. Samples the next token based on the last one.
      *
      * @param lastToken ID of the last token.

--- a/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
@@ -138,6 +138,24 @@ object LlamaCpp {
     }
 
     /**
+     * Function to get the end-of-generation (eog) token of the LLM.
+     * If the LLM has multiple eog tokens, the first one is returned.
+     *
+     * @return ID of the eog token.
+     */
+    fun getEndOfGeneration(): Int {
+        var eogTokens = intArrayOf()
+
+        for (token in 0 until getVocabSize()) {
+            if (isEndOfGeneration(token)) {
+                eogTokens += token
+            }
+        }
+
+        return eogTokens.first()
+    }
+
+    /**
      * Function to format a list of messages as a llama.cpp chat (i.e. apply the chat template of the LLM).
      * Creates the context needed to do steganography encoding/decoding in a conversation.
      *

--- a/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
@@ -257,17 +257,6 @@ object LlamaCpp {
     external fun detokenize(tokens: IntArray, ctx: Long = this.ctx): String
 
     /**
-     * Wrapper for the `llama_get_logits` function of llama.cpp. Calculates the logit matrix (i.e. predictions for every token in the prompt).
-     *
-     * Only the last row of the `n_tokens` x `n_vocab` matrix is actually needed as it contains the logits corresponding to the last token of the prompt.
-     *
-     * @param tokens Token IDs from tokenization of the prompt.
-     * @param ctx Memory address of the context.
-     * @return The logit matrix.
-     */
-    external fun getLogits(tokens: IntArray, ctx: Long = this.ctx): Array<FloatArray>
-
-    /**
      * Wrapper for the `llama_vocab_is_eog` and `llama_vocab_is_control` functions of llama.cpp. Checks if a token is a special token.
      *
      * @param token Token ID to check.
@@ -284,6 +273,17 @@ object LlamaCpp {
      * @return Boolean that is true if the token is an eog token, false otherwise.
      */
     private external fun isEndOfGeneration(token: Int, model: Long = this.model): Boolean
+
+    /**
+     * Wrapper for the `llama_get_logits` function of llama.cpp. Calculates the logit matrix (i.e. predictions for every token in the prompt).
+     *
+     * Only the last row of the `n_tokens` x `n_vocab` matrix is actually needed as it contains the logits corresponding to the last token of the prompt.
+     *
+     * @param tokens Token IDs from tokenization of the prompt.
+     * @param ctx Memory address of the context.
+     * @return The logit matrix.
+     */
+    external fun getLogits(tokens: IntArray, ctx: Long = this.ctx): Array<FloatArray>
 
     /**
      * Wrapper for the `llama_sampler_sample` function of llama.cpp. Samples the next token based on the last one.

--- a/app/src/main/java/org/vonderheidt/hips/utils/Statistics.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Statistics.kt
@@ -1,0 +1,34 @@
+package org.vonderheidt.hips.utils
+
+import kotlin.math.exp
+
+/**
+ * Object (i.e. singleton class) that represents statistical functions.
+ */
+object Statistics {
+    /**
+     * Function to normalize logits to probabilities.
+     *
+     * @param logits A vector of logits.
+     * @return The vector of probabilities.
+     */
+    fun softmax(logits: FloatArray): FloatArray {
+        // Initialize probability vector
+        val probabilities = FloatArray(logits.size) { 0f }
+
+        // Calculate normalization factor for denominator
+        var denominator = 0.0
+
+        for (token in logits.indices) {
+            // Uses exponential function since it's strictly monotonous in growth, doesn't change ranking of tokens
+            denominator += exp(logits[token].toDouble())
+        }
+
+        // Normalize logits and fill probability vector
+        for (token in logits.indices) {
+            probabilities[token] = (exp(logits[token].toDouble()) / denominator).toFloat()
+        }
+
+        return probabilities
+    }
+}


### PR DESCRIPTION
Implemented steganography via arithmetic coding:
- Added softmax function
- Added more functions for formatting of bit strings
- Added function to get end-of-generation (eog) token of LLM
- Added UI for arithmetic parameters `topK` and `precision` to settings screen
- Added first draft of arithmetic coding
- Some minor cleanups

Open TODOs:
- Arithmetic coding only works for steganography, not for binary conversion, as LLM doesn't predict tokens of secret message correctly when context is only an eog token