### PR TITLE
Refine arithmetic compression

### DIFF
--- a/app/src/main/java/org/vonderheidt/hips/data/Settings.kt
+++ b/app/src/main/java/org/vonderheidt/hips/data/Settings.kt
@@ -15,7 +15,7 @@ object Settings {
         We talk about what we did on the weekend.
         Be brief and casual, but friendly and engaging. Use emojis and phrases typical for chat messages.
     """.trimIndent().replace("\n", " ")
-    private val defaultNumberOfMessages = 0
+    private val defaultNumberOfMessages = 2
     private val defaultSteganographyMode = SteganographyMode.Arithmetic
     private val defaultTemperature = 1.0f
     private val defaultTopK = 0             // Only used if LLM is not in memory

--- a/app/src/main/java/org/vonderheidt/hips/data/Settings.kt
+++ b/app/src/main/java/org/vonderheidt/hips/data/Settings.kt
@@ -11,9 +11,9 @@ object Settings {
     // Define default values
     private val defaultConversionMode = ConversionMode.Arithmetic
     private val defaultSystemPrompt = """
-        You and I are friends, talking about what we did on the weekend.
-        Use phrases and abbreviations typical for chat messages.
-        Be brief and casual, but friendly and engaging.
+        Let's do a role play. You and I are friends, texting with each other.
+        We talk about what we did on the weekend.
+        Be brief and casual, but friendly and engaging. Use emojis and phrases typical for chat messages.
     """.trimIndent().replace("\n", " ")
     private val defaultNumberOfMessages = 0
     private val defaultSteganographyMode = SteganographyMode.Arithmetic

--- a/app/src/main/java/org/vonderheidt/hips/data/Settings.kt
+++ b/app/src/main/java/org/vonderheidt/hips/data/Settings.kt
@@ -3,6 +3,8 @@ package org.vonderheidt.hips.data
 import org.vonderheidt.hips.utils.ConversionMode
 import org.vonderheidt.hips.utils.LlamaCpp
 import org.vonderheidt.hips.utils.SteganographyMode
+import kotlin.math.ceil
+import kotlin.math.log2
 
 /**
  * Object (i.e. singleton class) that represents the user settings. Holds default values to be set upon installation of this app.
@@ -52,7 +54,7 @@ object Settings {
         }
         if (llm) {
             topK = if (LlamaCpp.isInMemory()) LlamaCpp.getVocabSize() else defaultTopK
-            precision = defaultPrecision
+            precision = if (LlamaCpp.isInMemory()) ceil(log2(topK.toFloat())).toInt() else defaultPrecision
         }
     }
 }

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
@@ -70,6 +70,7 @@ import org.vonderheidt.hips.utils.ConversionMode
 import org.vonderheidt.hips.utils.Huffman
 import org.vonderheidt.hips.utils.LlamaCpp
 import org.vonderheidt.hips.utils.Steganography
+import org.vonderheidt.hips.utils.SteganographyMode
 
 /**
  * Function that defines the conversation screen.
@@ -178,6 +179,11 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                             // Check if LLM is loaded
                             if (!LlamaCpp.isInMemory()) {
                                 Toast.makeText(currentLocalContext, "Load LLM into memory first", Toast.LENGTH_LONG).show()
+                                return@IconButton
+                            }
+                            // Check settings
+                            if (Settings.steganographyMode == SteganographyMode.Arithmetic && (Settings.topK == 0 || Settings.precision == 0)) {
+                                Toast.makeText(currentLocalContext, "Arithmetic coding needs topK > 0 and precision > 0", Toast.LENGTH_LONG).show()
                                 return@IconButton
                             }
                             // Only 1 message can be decoded at a time
@@ -399,6 +405,11 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                                         // Check if LLM is loaded
                                         if (!LlamaCpp.isInMemory()) {
                                             Toast.makeText(currentLocalContext, "Load LLM into memory first", Toast.LENGTH_LONG).show()
+                                            return@detectTapGestures
+                                        }
+                                        // Check settings
+                                        if (Settings.steganographyMode == SteganographyMode.Arithmetic && (Settings.topK == 0 || Settings.precision == 0)) {
+                                            Toast.makeText(currentLocalContext, "Arithmetic coding needs topK > 0 and precision > 0", Toast.LENGTH_LONG).show()
                                             return@detectTapGestures
                                         }
                                         // Only send non-blank messages, allows to switch user on button press

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/HomeScreen.kt
@@ -65,6 +65,7 @@ import org.vonderheidt.hips.utils.ConversionMode
 import org.vonderheidt.hips.utils.LLM
 import org.vonderheidt.hips.utils.LlamaCpp
 import org.vonderheidt.hips.utils.Steganography
+import org.vonderheidt.hips.utils.SteganographyMode
 
 /**
  * Function that defines the home screen.
@@ -286,6 +287,10 @@ fun HomeScreen(navController: NavController, modifier: Modifier) {
                     // Check settings
                     if (Settings.conversionMode == ConversionMode.Huffman) {
                         Toast.makeText(currentLocalContext, "Huffman compression can't be used here", Toast.LENGTH_LONG).show()
+                        return@Button
+                    }
+                    if (Settings.steganographyMode == SteganographyMode.Arithmetic && (Settings.topK == 0 || Settings.precision == 0)) {
+                        Toast.makeText(currentLocalContext, "Arithmetic coding needs topK > 0 and precision > 0", Toast.LENGTH_LONG).show()
                         return@Button
                     }
                     // Check inputs

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
@@ -510,7 +510,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                             Spacer(modifier = modifier.height(16.dp))
 
                             // Precision
-                            Text(text = "Set the precision for token sampling (recommended is around log₂($selectedTopK) = ${String.format(Locale.ENGLISH, "%.1f", log2(selectedTopK.toFloat()))} bits).")
+                            Text(text = "Set the precision for token sampling (recommended is around log₂($selectedTopK) = ${String.format(Locale.ENGLISH, "%.1f", log2(selectedTopK.toFloat()))} bits, extremes produce longer cover texts).")
 
                             Spacer(modifier = modifier.height(16.dp))
 

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
@@ -515,6 +515,8 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                             Spacer(modifier = modifier.height(16.dp))
 
                             // Again, do int conversion here as slider only allows floats
+                            // Don't expose 64 bit precision from Arithmetic compression in UI for steganography, encoding would take ages and offer no benefit with vocabulary sizes of current LLMs
+                            // Using 64 bits internally also avoids integer overflows at 31-32 bits
                             Slider(
                                 value = selectedPrecision.toFloat(),
                                 onValueChange = {

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
@@ -446,7 +446,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                 // Specific settings for each steganography mode
                 when (selectedSteganographyMode) {
                     SteganographyMode.Arithmetic -> {
-                        Text(text = "Set the temperature for token sampling (\"creativity\" of the LLM).")
+                        Text(text = "Set the temperature for token sampling (\"creativity\" of the LLM, you can play around with this).")
 
                         Spacer(modifier = modifier.height(16.dp))
 

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
@@ -480,7 +480,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                         // Show settings specific to LLM only when it is in memory
                         if (isInMemory) {
                             // Top k
-                            Text(text = "Set the top k for token sampling.")
+                            Text(text = "Set the top k for token sampling (number of most likely tokens from the LLM's vocabulary to consider, 100% is recommended).")
 
                             Spacer(modifier = modifier.height(16.dp))
 

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
@@ -71,7 +71,7 @@ import org.vonderheidt.hips.utils.ConversionMode
 import org.vonderheidt.hips.utils.LLM
 import org.vonderheidt.hips.utils.LlamaCpp
 import org.vonderheidt.hips.utils.SteganographyMode
-import java.util.Locale
+import kotlin.math.ceil
 import kotlin.math.log2
 import kotlin.math.roundToInt
 
@@ -446,7 +446,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                 // Specific settings for each steganography mode
                 when (selectedSteganographyMode) {
                     SteganographyMode.Arithmetic -> {
-                        Text(text = "Set the temperature for token sampling (\"creativity\" of the LLM, you can play around with this).")
+                        Text(text = "Set the temperature for token sampling. This is the \"creativity\" of the LLM. You can play around with it.")
 
                         Spacer(modifier = modifier.height(16.dp))
 
@@ -480,7 +480,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                         // Show settings specific to LLM only when it is in memory
                         if (isInMemory) {
                             // Top k
-                            Text(text = "Set the top k for token sampling (number of most likely tokens from the LLM's vocabulary to consider, 100% is recommended).")
+                            Text(text = "Set the top k for token sampling. This is the number of most likely tokens from the LLM's vocabulary to consider. 100% (= ${LlamaCpp.getVocabSize()} tokens) is recommended.")
 
                             Spacer(modifier = modifier.height(16.dp))
 
@@ -510,7 +510,11 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                             Spacer(modifier = modifier.height(16.dp))
 
                             // Precision
-                            Text(text = "Set the precision for token sampling (recommended is around log₂($selectedTopK) = ${String.format(Locale.ENGLISH, "%.1f", log2(selectedTopK.toFloat()))} bits, extremes produce longer cover texts).")
+                            Text(
+                                text = "Set the precision for token sampling. Recommended is ⌈log₂($selectedTopK)⌉ = "
+                                        + if (selectedTopK > 0) { "${ceil(log2(selectedTopK.toFloat())).toInt()}" } else { "n/a" }
+                                        + " bits. Other values can be more efficient, but extremes produce long cover texts."
+                            )
 
                             Spacer(modifier = modifier.height(16.dp))
 
@@ -581,7 +585,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                     }
                     */
                     SteganographyMode.Huffman -> {
-                        Text(text = "Set the bits per token (higher is more efficient, but less coherent).")
+                        Text(text = "Set the number of bits to encode per cover text token. Higher is more efficient, but less coherent.")
 
                         Spacer(modifier = modifier.height(16.dp))
 

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
@@ -71,6 +71,8 @@ import org.vonderheidt.hips.utils.ConversionMode
 import org.vonderheidt.hips.utils.LLM
 import org.vonderheidt.hips.utils.LlamaCpp
 import org.vonderheidt.hips.utils.SteganographyMode
+import java.util.Locale
+import kotlin.math.log2
 import kotlin.math.roundToInt
 
 /**
@@ -508,7 +510,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                             Spacer(modifier = modifier.height(16.dp))
 
                             // Precision
-                            Text(text = "Set the precision for token sampling.")
+                            Text(text = "Set the precision for token sampling (recommended is around log₂($selectedTopK) = ${String.format(Locale.ENGLISH, "%.1f", log2(selectedTopK.toFloat()))} bits).")
 
                             Spacer(modifier = modifier.height(16.dp))
 

--- a/app/src/main/java/org/vonderheidt/hips/utils/Arithmetic.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Arithmetic.kt
@@ -388,6 +388,7 @@ object Arithmetic {
 
             if (overfill.isNotEmpty()) {
                 cumulatedProbabilities = cumulatedProbabilities.dropLast(overfill.size).toMutableList()
+                /*
                 // Reassignment of k is new in decode, but not used here as possible BPE errors are ignored below
                 // Logic of Stegasuras is somewhat inverted again
                 // Stegasuras: overfill_index[0] = Index of first token with cumulated probability > cur_int_range
@@ -397,6 +398,7 @@ object Arithmetic {
                 //       != Size of cumulatedProbabilities after it was overwritten here
                 // Now "if (rank >= k) { ... }" from BPE fixes below makes sense
                 k = cumulatedProbabilities.size
+                */
             }
 
             // Stegasuras: "Add any mass to the top if removing/rounding causes the total prob to be too small"
@@ -420,6 +422,7 @@ object Arithmetic {
             // Determine rank of predicted token amongst all tokens based on its probability
             var rank = scaledProbabilities.indexOfFirst { it.first == coverTextTokens[i] }
 
+            /*
             // Stegasuras: "Handle most errors that could happen because of BPE with heuristic"
             // Rank can't exceed cumulatedProbabilities indices
             // TODO
@@ -507,6 +510,7 @@ object Arithmetic {
                     rank = 0
                 }
             }
+            */
 
             // Sample token at (corrected) rank
             val selectedSubinterval = rank

--- a/app/src/main/java/org/vonderheidt/hips/utils/Arithmetic.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Arithmetic.kt
@@ -104,12 +104,8 @@ object Arithmetic {
             // Suppress special tokens to avoid early termination before all bits of secret message are encoded
             LlamaCpp.suppressSpecialTokens(logits)
 
-            // <Logic specific to arithmetic coding>
-
             // Normalize logits to probabilities
             val probabilities = Statistics.softmax(logits)
-
-            // </Logic specific to arithmetic coding>
 
             // Arithmetic sampling to encode bits of secret message into tokens
             if (i < cipherBitString.length) {
@@ -338,10 +334,10 @@ object Arithmetic {
             // Suppress special tokens
             LlamaCpp.suppressSpecialTokens(logits)
 
-            // <Logic specific to arithmetic coding>
-
             // Similar to encode
             val probabilities = Statistics.softmax(logits)
+
+            // <Logic specific to arithmetic coding>
 
             val scaledProbabilities = probabilities
                 .mapIndexed { token, probability -> token to probability/temperature }

--- a/app/src/main/java/org/vonderheidt/hips/utils/Arithmetic.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Arithmetic.kt
@@ -101,11 +101,11 @@ object Arithmetic {
             // Only last row of logit matrix is needed as it contains logits corresponding to last token of the prompt
             val logits = LlamaCpp.getLogits(if (isFirstRun) contextTokens else intArrayOf(sampledToken)).last()
 
-            // Suppress special tokens to avoid early termination before all bits of secret message are encoded
-            LlamaCpp.suppressSpecialTokens(logits)
-
             // Normalize logits to probabilities
             val probabilities = Statistics.softmax(logits)
+
+            // Suppress special tokens to avoid early termination before all bits of secret message are encoded
+            LlamaCpp.suppressSpecialTokens(probabilities)
 
             // Arithmetic sampling to encode bits of secret message into tokens
             if (i < cipherBitString.length) {
@@ -331,11 +331,11 @@ object Arithmetic {
             // Calculate the logit matrix again initially from context tokens, then from last cover text token, and get last row
             val logits = LlamaCpp.getLogits(if (isFirstRun) contextTokens else intArrayOf(coverTextToken)).last()
 
-            // Suppress special tokens
-            LlamaCpp.suppressSpecialTokens(logits)
-
             // Similar to encode
             val probabilities = Statistics.softmax(logits)
+
+            // Suppress special tokens
+            LlamaCpp.suppressSpecialTokens(probabilities)
 
             // <Logic specific to arithmetic coding>
 

--- a/app/src/main/java/org/vonderheidt/hips/utils/Arithmetic.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Arithmetic.kt
@@ -25,7 +25,7 @@ object Arithmetic {
             coverText = preparedSecretMessage,
             temperature = 1.0f,
             topK = LlamaCpp.getVocabSize(),
-            precision = 30
+            precision = 62
         )
     }
 
@@ -44,7 +44,7 @@ object Arithmetic {
             cipherBits = paddedPlainBits,
             temperature = 1.0f,
             topK = LlamaCpp.getVocabSize(),
-            precision = 30
+            precision = 62
         )
     }
 
@@ -83,7 +83,7 @@ object Arithmetic {
 
         // Define initial interval as [0, 2^precision)
         // Stegasuras variable "max_val" is redundant
-        val currentInterval = intArrayOf(0, 1 shl precision) // Stegasuras: "Bottom inclusive, top exclusive"
+        val currentInterval = longArrayOf(0L, 1L shl precision) // Stegasuras: "Bottom inclusive, top exclusive"
 
         // </Logic specific to arithmetic coding>
 
@@ -167,8 +167,8 @@ object Arithmetic {
 
                 // Replace probability with cumulated probability
                 // Probabilities that would round to 0 were cut off earlier, so all at least round to 1, no collisions possible
-                var cumulatedProbabilities = mutableListOf<Pair<Int, Int>>()
-                var cumulatedProbability = 0
+                var cumulatedProbabilities = mutableListOf<Pair<Int, Long>>()
+                var cumulatedProbability = 0L
 
                 for ((token, probability) in roundedScaledProbabilities) {
                     cumulatedProbability += probability
@@ -223,7 +223,7 @@ object Arithmetic {
                 // Find position of first token with cumulated probability larger than this integer, i.e. find relevant sub-interval of current interval
                 // => sampledToken is already determined here, next steps only calculate new interval
                 // Stegasuras variable "message_idx" is redundant
-                val selectedSubinterval = cumulatedProbabilities.indexOfFirst { it.second > Format.asInteger(cipherBitSubstring) }  // Stegasuras would reverse cipherBitSubstring, shouldn't be necessary here
+                val selectedSubinterval = cumulatedProbabilities.indexOfFirst { it.second > Format.asLong(cipherBitSubstring) }  // Stegasuras would reverse cipherBitSubstring, shouldn't be necessary here
 
                 // Stegasuras: "Calculate new range as ints"
                 // Calculate bottom and top of relevant sub-interval for next iteration
@@ -248,8 +248,8 @@ object Arithmetic {
                 val newIntervalBottomBits = newIntervalBottomBitsInclusive.substring(startIndex = numberOfEncodedBits) + "0".repeat(numberOfEncodedBits)
                 val newIntervalTopBits = newIntervalTopBitsInclusive.substring(startIndex = numberOfEncodedBits) + "1".repeat(numberOfEncodedBits)
 
-                currentInterval[0] = Format.asInteger(newIntervalBottomBits)                            // Again, reversing shouldn't be necessary here
-                currentInterval[1] = Format.asInteger(newIntervalTopBits) + 1                           // Stegasuras: "+1 here because upper bound is exclusive"
+                currentInterval[0] = Format.asLong(newIntervalBottomBits)                            // Again, reversing shouldn't be necessary here
+                currentInterval[1] = Format.asLong(newIntervalTopBits) + 1                           // Stegasuras: "+1 here because upper bound is exclusive"
 
                 // Sample token as determined above
                 sampledToken = cumulatedProbabilities[selectedSubinterval].first
@@ -313,7 +313,7 @@ object Arithmetic {
             // Not done here as ASCII NUL is used instead (see translation of "partial" variable in encode)
         }
 
-        val currentInterval = intArrayOf(0, 1 shl precision)
+        val currentInterval = longArrayOf(0L, 1L shl precision)
 
         // </Logic specific to arithmetic coding>
 
@@ -375,8 +375,8 @@ object Arithmetic {
                 Pair(it.first, it.second.roundToInt())
             }
 
-            var cumulatedProbabilities = mutableListOf<Pair<Int, Int>>()
-            var cumulatedProbability = 0
+            var cumulatedProbabilities = mutableListOf<Pair<Int, Long>>()
+            var cumulatedProbability = 0L
 
             for ((token, probability) in roundedScaledProbabilities) {
                 cumulatedProbability += probability
@@ -533,8 +533,8 @@ object Arithmetic {
             val newIntervalBottomBits = newIntervalBottomBitsInclusive.substring(startIndex = numberOfEncodedBits) + "0".repeat(numberOfEncodedBits)
             val newIntervalTopBits = newIntervalTopBitsInclusive.substring(startIndex = numberOfEncodedBits) + "1".repeat(numberOfEncodedBits)
 
-            currentInterval[0] = Format.asInteger(newIntervalBottomBits)
-            currentInterval[1] = Format.asInteger(newIntervalTopBits) + 1
+            currentInterval[0] = Format.asLong(newIntervalBottomBits)
+            currentInterval[1] = Format.asLong(newIntervalTopBits) + 1
 
             // </Logic specific to arithmetic coding>
 

--- a/app/src/main/java/org/vonderheidt/hips/utils/Format.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Format.kt
@@ -95,40 +95,41 @@ object Format {
     }
 
     /**
-     * Function to format an integer as a bit string of desired length. Pads the bit string with leading 0s if needed.
+     * Function to format a Long number as a bit string of desired length. Pads the bit string with leading 0s if needed.
      *
-     * Corresponds to Stegasuras method `int2bits` in `utils.py`. Parameter `inp` was renamed to `integer`, `num_bits` to `numberOfBits`.
+     * Corresponds to Stegasuras method `int2bits` in `utils.py`. Parameter `inp` was renamed to `long`, `num_bits` to `numberOfBits`.
      *
-     * @param integer An integer.
+     * @param long A Long number.
      * @param numberOfBits The desired length of the bit string.
      * @return The bit string.
      */
-    fun asBitString(integer: Int, numberOfBits: Int): String {
+    fun asBitString(long: Long, numberOfBits: Int): String {
         // Only edge case covered in Stegasuras
         if (numberOfBits == 0) {
             return ""
         }
 
-        // Convert integer to bit string of minimum necessary length and pad it to desired length
-        val bitString = Integer
-            .toBinaryString(integer)
-            .padStart(numberOfBits, '0')
+        // Convert Long number to bit string of minimum necessary length and pad it to desired length
+        val bitString = long
+            .toString(radix = 2)
+            .padStart(length = numberOfBits, padChar = '0')
 
         return bitString
     }
 
     /**
-     * Function to reverse formatting of an integer as a bit string (i.e. to reverse `Format.asBitString(Int, Int)`).
+     * Function to reverse formatting of a Long number as a bit string (i.e. to reverse `Format.asBitString(Long, Int)`).
      *
      * Corresponds to Stegasuras method `bits2int` in `utils.py`. Parameter `bits` was renamed to `bitString`.
      *
-     * @param bitString A bit string containing an integer.
-     * @return The integer.
+     * @param bitString A bit string containing a Long number.
+     * @return The Long number.
      */
-    fun asInteger(bitString: String): Int {
-        val integer = bitString.toInt(radix = 2)
+    fun asLong(bitString: String): Long {
+        // Convert bit string to Long number, dropping leading 0s
+        val long = bitString.toLong(radix = 2)
 
-        return integer
+        return long
     }
 
     /**

--- a/app/src/main/java/org/vonderheidt/hips/utils/Huffman.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Huffman.kt
@@ -107,10 +107,13 @@ object Huffman {
             // Suppress special tokens to avoid early termination before all bits of secret message are encoded
             LlamaCpp.suppressSpecialTokens(logits)
 
+            // Normalize logits to probabilities
+            val probabilities = Statistics.softmax(logits)
+
             // Huffman sampling to encode bits of secret message into tokens
             if (i < cipherBitString.length) {
                 // Get top 2^bitsPerToken logits for last token of prompt (= height of Huffman tree)
-                val topLogits = getTopLogits(logits)
+                val topLogits = getTopLogits(probabilities)
 
                 // Construct Huffman tree from top logits
                 val huffmanCoding = HuffmanCoding<Int, Float>()
@@ -147,7 +150,7 @@ object Huffman {
             // Greedy sampling to pick most likely token until last sentence is finished
             else {
                 // Get most likely token by sampling top 2^0 = 1 tokens
-                sampledToken = getTopLogits(logits, 0).keys.first()
+                sampledToken = getTopLogits(probabilities, 0).keys.first()
 
                 // Update flag
                 isLastSentenceFinished = LlamaCpp.isEndOfSentence(sampledToken)
@@ -194,8 +197,11 @@ object Huffman {
             // Suppress special tokens
             LlamaCpp.suppressSpecialTokens(logits)
 
+            // Normalize logits to probabilities
+            val probabilities = Statistics.softmax(logits)
+
             // Get top 2^bitsPerToken logits
-            val topLogits = getTopLogits(logits)
+            val topLogits = getTopLogits(probabilities)
 
             // Construct Huffman tree
             val huffmanCoding = HuffmanCoding<Int, Float>()

--- a/app/src/main/java/org/vonderheidt/hips/utils/Huffman.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Huffman.kt
@@ -113,11 +113,11 @@ object Huffman {
             // Huffman sampling to encode bits of secret message into tokens
             if (i < cipherBitString.length) {
                 // Get top 2^bitsPerToken logits for last token of prompt (= height of Huffman tree)
-                val topLogits = getTopProbabilities(probabilities)
+                val topProbabilities = getTopProbabilities(probabilities)
 
                 // Construct Huffman tree from top logits
                 val huffmanCoding = HuffmanCoding<Int, Float>()
-                huffmanCoding.buildHuffmanTree(topLogits)
+                huffmanCoding.buildHuffmanTree(topProbabilities)
                 huffmanCoding.mergeHuffmanNodes()
                 val root = huffmanCoding.generateHuffmanCodes()
 
@@ -201,11 +201,11 @@ object Huffman {
             LlamaCpp.suppressSpecialTokens(probabilities)
 
             // Get top 2^bitsPerToken logits
-            val topLogits = getTopProbabilities(probabilities)
+            val topProbabilities = getTopProbabilities(probabilities)
 
             // Construct Huffman tree
             val huffmanCoding = HuffmanCoding<Int, Float>()
-            huffmanCoding.buildHuffmanTree(topLogits)
+            huffmanCoding.buildHuffmanTree(topProbabilities)
             huffmanCoding.mergeHuffmanNodes()
             huffmanCoding.generateHuffmanCodes()        // Return value (root) is not needed here as Huffman tree is not traversed manually
 
@@ -235,12 +235,12 @@ object Huffman {
      * @return Map of top 2^bitsPerToken probabilities and the corresponding token IDs.
      */
     private fun getTopProbabilities(probabilities: FloatArray, bitsPerToken: Int = Settings.bitsPerToken): Map<Int, Float> {
-        val topLogits = probabilities
+        val topProbabilities = probabilities
             .mapIndexed{ token, logit -> token to logit }   // Convert to List<Pair<Int, Float>> so token IDs won't get lost
             .sortedByDescending { it.second }               // Sort pairs descending based on logits
             .take(1 shl bitsPerToken)                       // Take top 2^bitsPerToken pairs
             .toMap()                                        // Convert to Map<Int, Float> for Huffman tree (ensures there can't be any duplicate token IDs)
 
-        return topLogits
+        return topProbabilities
     }
 }

--- a/app/src/main/java/org/vonderheidt/hips/utils/Huffman.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/Huffman.kt
@@ -104,11 +104,11 @@ object Huffman {
             // Only last row of logit matrix is needed as it contains logits corresponding to last token of the prompt
             val logits = LlamaCpp.getLogits(if (isFirstRun) contextTokens else intArrayOf(sampledToken)).last()
 
-            // Suppress special tokens to avoid early termination before all bits of secret message are encoded
-            LlamaCpp.suppressSpecialTokens(logits)
-
             // Normalize logits to probabilities
             val probabilities = Statistics.softmax(logits)
+
+            // Suppress special tokens to avoid early termination before all bits of secret message are encoded
+            LlamaCpp.suppressSpecialTokens(probabilities)
 
             // Huffman sampling to encode bits of secret message into tokens
             if (i < cipherBitString.length) {
@@ -194,11 +194,11 @@ object Huffman {
             // Calculate the logit matrix again initially from context tokens, then from last cover text token, and get last row
             val logits = LlamaCpp.getLogits(if (isFirstRun) contextTokens else intArrayOf(coverTextToken)).last()
 
-            // Suppress special tokens
-            LlamaCpp.suppressSpecialTokens(logits)
-
             // Normalize logits to probabilities
             val probabilities = Statistics.softmax(logits)
+
+            // Suppress special tokens
+            LlamaCpp.suppressSpecialTokens(probabilities)
 
             // Get top 2^bitsPerToken logits
             val topLogits = getTopLogits(probabilities)

--- a/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
@@ -129,7 +129,7 @@ object LlamaCpp {
         // Suppress special tokens by setting their logits to negative values
         for (token in logits.indices) {
             if (isSpecial(token)) {
-                logits[token] = -100f
+                logits[token] = 0f
             }
         }
     }

--- a/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
+++ b/app/src/main/java/org/vonderheidt/hips/utils/LlamaCpp.kt
@@ -116,20 +116,18 @@ object LlamaCpp {
     }
 
     /**
-     * Function to suppress special tokens, i.e. eog (end-of-generation) and control tokens.
+     * Function to suppress special tokens, i.e. end-of-generation (eog) and control tokens.
      *
      * Suppressing eog tokens is needed to avoid early termination when generating a cover text.
+     * Additionally suppressing control tokens is needed to avoid artefacts when generating a conversation of cover texts.
      *
-     * Additionally suppressing control tokens is beneficial because the cover text then can't contain any invisible tokens.
-     * This ensures integrity when using a non-digital communication medium.
-     *
-     * @param logits Logits for the last token of the prompt (= last row of logits matrix).
+     * @param probabilities Probabilities for the last token of the prompt (= last row of logits matrix after normalization).
      */
-    fun suppressSpecialTokens(logits: FloatArray) {
-        // Suppress special tokens by setting their logits to negative values
-        for (token in logits.indices) {
+    fun suppressSpecialTokens(probabilities: FloatArray) {
+        // Suppress special tokens by setting their probabilities to 0
+        for (token in probabilities.indices) {
             if (isSpecial(token)) {
-                logits[token] = 0f
+                probabilities[token] = 0f
             }
         }
     }


### PR DESCRIPTION
Refined implementation of arithmetic compression:
- Increased `precision` from `30` to `62` bits by storing `2^precision` as `Long` instead of `Int`
- Moved call of `suppressSpecialTokens` after `softmax`, i.e. set their probability to `0f` now
- Improved explanation of parameters on settings screen
- Reset `precision` to `ceil(log2(topK))` when LLM is in memory
- Added check for `topK > 0` and `precision > 0` on home screen and conversation screen
- Commented out BPE fixes for testing
- Improved comments

Unrelated changes:
- Added softmax to Huffman coding as well
- Changed some default settings