### PR TITLE
Refactor: Improve UI spacing for a more compact layout

### DIFF
--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/ConversationScreen.kt
@@ -112,7 +112,7 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
 
     // UI components
     Column(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize().padding(horizontal = 4.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         // Back button
@@ -149,8 +149,8 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
         // Chat partner
         Row(
             modifier = modifier
-                .fillMaxWidth(0.95f)
-                .height(48.dp),
+                .fillMaxWidth()
+                .height(40.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             // Profile picture
@@ -160,12 +160,12 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                 modifier = modifier.size(24.dp)
             )
 
-            Spacer(modifier = modifier.width(8.dp))
+            Spacer(modifier = modifier.width(4.dp))
 
             // Name
             Text(
                 text = "Demo",
-                fontSize = 24.sp,
+                fontSize = 20.sp,
             )
 
             // Profile picture and name on the left, buttons on the right
@@ -270,13 +270,11 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
             }
         }
 
-        Spacer(modifier = modifier.height(8.dp))
-
         // Messages
         // Use LazyColumn as it only loads visible messages into memory, allowing for arbitrary number of messages
         LazyColumn(
             modifier = modifier
-                .fillMaxWidth(0.95f)
+                .fillMaxWidth()
                 .weight(1f)
         ) {
             // Current user (senderID == 0) is right aligned and green
@@ -296,7 +294,7 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                             .graphicsLayer(
                                 alpha = if (selectedMessages.isEmpty() || message in selectedMessages) { 1f } else { 0.25f }
                             )
-                            .padding(8.dp)
+                            .padding(4.dp)
                             .pointerInput(Unit) {
                                 detectTapGestures(
                                     onLongPress = {
@@ -325,7 +323,7 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                         if (isDecoding && message == messageToDecode) {
                             CircularProgressIndicator(
                                 modifier = modifier
-                                    .padding(8.dp)
+                                    .padding(4.dp)
                                     .align(Alignment.Center),
                                 color = Color.White
                             )
@@ -339,13 +337,11 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                         }
                     }
                 }
-
-                Spacer(modifier = modifier.height(8.dp))
             }
         }
 
         Row(
-            modifier = modifier.fillMaxWidth(0.95f),
+            modifier = modifier.fillMaxWidth(),
             verticalAlignment = Alignment.Bottom
         ) {
             // Input field for new message
@@ -367,7 +363,7 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                 maxLines = 5
             )
 
-            Spacer(modifier = modifier.width(8.dp))
+            Spacer(modifier = modifier.width(4.dp))
 
             // Send button
             // Colour corresponds to user a new message is being sent as
@@ -482,8 +478,6 @@ fun ConversationScreen(navController: NavController, modifier: Modifier) {
                 }
             }
         }
-
-        Spacer(modifier = modifier.height(8.dp))
     }
 }
 

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/HomeScreen.kt
@@ -9,10 +9,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -99,8 +97,10 @@ fun HomeScreen(navController: NavController, modifier: Modifier) {
     Column(
         modifier = modifier
             .fillMaxSize()
-            .verticalScroll(state = scrollState),
-        horizontalAlignment = Alignment.CenterHorizontally
+            .verticalScroll(state = scrollState)
+            .padding(horizontal = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         Row(
             modifier = modifier.fillMaxWidth(),
@@ -149,13 +149,11 @@ fun HomeScreen(navController: NavController, modifier: Modifier) {
             )
         }
 
-        Spacer(modifier = modifier.height(32.dp))
-
         // 1st input is context
         OutlinedTextField(
             value = context,
             onValueChange = { context = it },
-            modifier = modifier.fillMaxWidth(0.8f),
+            modifier = modifier.fillMaxWidth(),
             label = { Text(text = "Context") },
             leadingIcon = {
                 Icon(
@@ -175,14 +173,12 @@ fun HomeScreen(navController: NavController, modifier: Modifier) {
             maxLines = 5
         )
 
-        Spacer(modifier = modifier.height(32.dp))
-
         // 2nd input is either secret message or cover text
         if (selectedMode == 0) {
             OutlinedTextField(
                 value = secretMessage,
                 onValueChange = { secretMessage = it },
-                modifier = modifier.fillMaxWidth(0.8f),
+                modifier = modifier.fillMaxWidth(),
                 label = { Text(text = "Secret message") },
                 leadingIcon = {
                     Icon(
@@ -206,7 +202,7 @@ fun HomeScreen(navController: NavController, modifier: Modifier) {
             OutlinedTextField(
                 value = coverText,
                 onValueChange = { coverText = it },
-                modifier = modifier.fillMaxWidth(0.8f),
+                modifier = modifier.fillMaxWidth(),
                 label = { Text(text = "Cover text") },
                 leadingIcon = {
                     Icon(
@@ -227,11 +223,9 @@ fun HomeScreen(navController: NavController, modifier: Modifier) {
             )
         }
 
-        Spacer(modifier = modifier.height(16.dp))
-
         // Switch for conversation vs completion
         Row(
-            modifier = modifier.fillMaxWidth(0.8f),
+            modifier = modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -243,10 +237,8 @@ fun HomeScreen(navController: NavController, modifier: Modifier) {
             )
         }
 
-        Spacer(modifier = modifier.height(16.dp))
-
         Row(
-            modifier = modifier.fillMaxWidth(0.8f),
+            modifier = modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             // Mode selector
@@ -369,54 +361,46 @@ fun HomeScreen(navController: NavController, modifier: Modifier) {
 
         // Loading animation to show when start button is pressed
         if (isLoading) {
-            Spacer (modifier = modifier.height(64.dp))
-
             CircularProgressIndicator()
         }
 
         // Output is either cover text or secret message
         // Only show when encode or decode is finished (i.e. also not on app startup)
         if (isOutputVisible) {
-            Spacer(modifier = modifier.height(32.dp))
+            Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (selectedMode == 0) {
+                    Text(
+                        text = "Cover text (tap to copy):",
+                        fontWeight = FontWeight.Bold
+                    )
 
-            if (selectedMode == 0) {
-                Text(
-                    text = "Cover text (tap to copy):",
-                    fontWeight = FontWeight.Bold
-                )
+                    Text(
+                        text = coverText,
+                        modifier = modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                // Copy cover text to clipboard
+                                val clip = ClipData.newPlainText("Cover text", coverText)
+                                clipboardManager.setPrimaryClip(clip)
 
-                Spacer(modifier = modifier.height(16.dp))
+                                // Show confirmation via toast message
+                                Toast.makeText(currentLocalContext, "Copied to clipboard", Toast.LENGTH_LONG).show()
+                            }
+                    )
+                }
+                else {
+                    Text(
+                        text = "Secret message:",
+                        fontWeight = FontWeight.Bold
+                    )
 
-                Text(
-                    text = coverText,
-                    modifier = modifier
-                        .fillMaxWidth(0.8f)
-                        .clickable {
-                            // Copy cover text to clipboard
-                            val clip = ClipData.newPlainText("Cover text", coverText)
-                            clipboardManager.setPrimaryClip(clip)
-
-                            // Show confirmation via toast message
-                            Toast.makeText(currentLocalContext, "Copied to clipboard", Toast.LENGTH_LONG).show()
-                        }
-                )
-            }
-            else {
-                Text(
-                    text = "Secret message:",
-                    fontWeight = FontWeight.Bold
-                )
-
-                Spacer(modifier = modifier.height(16.dp))
-
-                Text(
-                    text = secretMessage,
-                    modifier = modifier.fillMaxWidth(0.8f)
-                )
+                    Text(
+                        text = secretMessage,
+                        modifier = modifier.fillMaxWidth()
+                    )
+                }
             }
         }
-
-        Spacer(modifier = modifier.height(32.dp))
     }
 }
 

--- a/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/vonderheidt/hips/ui/screens/SettingsScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
@@ -113,8 +114,10 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
     Column(
         modifier = modifier
             .fillMaxSize()
-            .verticalScroll(state = scrollState),
-        horizontalAlignment = Alignment.CenterHorizontally
+            .verticalScroll(state = scrollState)
+            .padding(horizontal = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         // Back button
         // No explicit alignment (via modifier or horizontalArrangement argument) needed here since left align is default
@@ -142,7 +145,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
 
         // LLM download hint
         Row(
-            modifier = modifier.fillMaxWidth(0.9f)
+            modifier = modifier.fillMaxWidth()
         ) {
             if (isDownloaded) {
                 Icon(
@@ -175,8 +178,6 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
             }
         }
 
-        Spacer(modifier = modifier.height(16.dp))
-
         // Download button
         Row {
             Button(
@@ -193,12 +194,10 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
             }
         }
 
-        Spacer(modifier = modifier.height(16.dp))
-
         // Button to load LLM into memory
         if (isDownloaded) {
             Row(
-                modifier = modifier.fillMaxWidth(0.9f)
+                modifier = modifier.fillMaxWidth()
             ) {
                 Icon(
                     imageVector = if (!isInMemory) Icons.Outlined.PlayArrow else Icons.Outlined.Pause,
@@ -209,8 +208,6 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
 
                 Text(text = "The LLM needs to be loaded into memory.")
             }
-
-            Spacer(modifier = modifier.height(16.dp))
 
             Button(
                 onClick = {
@@ -233,13 +230,11 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
             ) {
                 Text(text = if (!isInMemory) "Start LLM" else "Stop LLM")
             }
-
-            Spacer(modifier = modifier.height(16.dp))
         }
 
         // Conversion settings
         Row(
-            modifier = modifier.fillMaxWidth(0.9f)
+            modifier = modifier.fillMaxWidth()
         ) {
             Icon(
                 imageVector = Icons.Outlined.Key,
@@ -248,7 +243,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
 
             Spacer(modifier = modifier.width(16.dp))
 
-            Column {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Text(
                     text = "Conversion",
                     fontSize = 18.sp,
@@ -256,8 +251,6 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                 )
 
                 Text(text = "Select how to convert the secret message from string to binary.")
-
-                Spacer(modifier = modifier.height(16.dp))
 
                 // Select conversion mode
                 ConversionMode.entries.toTypedArray().forEach { conversionMode ->
@@ -297,11 +290,9 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
             }
         }
 
-        Spacer(modifier = modifier.height(16.dp))
-
         // Steganography settings
         Row(
-            modifier = modifier.fillMaxWidth(0.9f)
+            modifier = modifier.fillMaxWidth()
         ) {
             Icon(
                 imageVector = Icons.Outlined.Lock,
@@ -310,7 +301,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
 
             Spacer(modifier = modifier.width(16.dp))
 
-            Column {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Text(
                     text = "Steganography",
                     fontSize = 18.sp,
@@ -319,8 +310,6 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
 
                 // Set system prompt
                 Text(text = "Set the system prompt to define the role the LLM takes in a conversation.")
-
-                Spacer(modifier = modifier.height(16.dp))
 
                 OutlinedTextField(
                     value = systemPrompt,
@@ -345,8 +334,6 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                     maxLines = 5
                 )
 
-                Spacer(modifier = modifier.height(8.dp))
-
                 Button(
                     onClick = {
                         if (systemPrompt.isBlank()) {
@@ -366,12 +353,8 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                     Text(text = "Save")
                 }
 
-                Spacer(modifier = modifier.height(16.dp))
-
                 // Select number of messages
                 Text(text = "Select the number of prior messages to use as context.")
-
-                Spacer(modifier = modifier.height(16.dp))
 
                 // Slider only allows floats, do int conversion here to abstract it away from state variable
                 Slider(
@@ -388,8 +371,6 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                     steps = 9
                 )
 
-                Spacer(modifier = modifier.height(8.dp))
-
                 Text(
                     text = when (selectedNumberOfMessages) {
                         0 -> "All messages"
@@ -399,11 +380,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                     modifier = modifier.align(Alignment.CenterHorizontally)
                 )
 
-                Spacer(modifier = modifier.height(16.dp))
-
                 Text(text = "Select how to encode the secret message into a cover text.")
-
-                Spacer(modifier = modifier.height(16.dp))
 
                 // Select steganography mode
                 SteganographyMode.entries.toTypedArray().forEach { steganographyMode ->
@@ -441,112 +418,96 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                     }
                 }
 
-                Spacer(modifier = modifier.height(16.dp))
-
                 // Specific settings for each steganography mode
                 when (selectedSteganographyMode) {
                     SteganographyMode.Arithmetic -> {
-                        Text(text = "Set the temperature for token sampling. This is the \"creativity\" of the LLM. You can play around with it.")
+                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                            Text(text = "Set the temperature for token sampling. This is the \"creativity\" of the LLM. You can play around with it.")
 
-                        Spacer(modifier = modifier.height(16.dp))
-
-                        // Scale up, round and scale down again to fix float artefacts (e.g. 1.299998 instead of 1.3)
-                        Slider(
-                            value = selectedTemperature * 10,
-                            onValueChange = {
-                                // Temperature can't be 0 because logits are scaled with 1/temperature
-                                if (it > 0f) {
-                                    // Update state variable
-                                    selectedTemperature = it.roundToInt() / 10f
-
-                                    // Update DataStore
-                                    Settings.temperature = it.roundToInt() / 10f
-                                    coroutineScope.launch { HiPSDataStore.writeSettings() }
-                                }
-                            },
-                            valueRange = 0f..20f,
-                            steps = 19
-                        )
-
-                        Spacer(modifier = modifier.height(8.dp))
-
-                        Text(
-                            text = "$selectedTemperature",
-                            modifier = modifier.align(Alignment.CenterHorizontally)
-                        )
-
-                        Spacer(modifier = modifier.height(16.dp))
-
-                        // Show settings specific to LLM only when it is in memory
-                        if (isInMemory) {
-                            // Top k
-                            Text(text = "Set the top k for token sampling. This is the number of most likely tokens from the LLM's vocabulary to consider. 100% (= ${LlamaCpp.getVocabSize()} tokens) is recommended.")
-
-                            Spacer(modifier = modifier.height(16.dp))
-
-                            // Again, do int conversion here as slider only allows floats
-                            // Display top k in %, but store absolute number internally
+                            // Scale up, round and scale down again to fix float artefacts (e.g. 1.299998 instead of 1.3)
                             Slider(
-                                value = (selectedTopK.toFloat() / LlamaCpp.getVocabSize() * 100),
+                                value = selectedTemperature * 10,
                                 onValueChange = {
-                                    // Update state variable
-                                    selectedTopK = (it / 100 * LlamaCpp.getVocabSize()).toInt()
+                                    // Temperature can't be 0 because logits are scaled with 1/temperature
+                                    if (it > 0f) {
+                                        // Update state variable
+                                        selectedTemperature = it.roundToInt() / 10f
 
-                                    // Update DataStore
-                                    Settings.topK = (it / 100 * LlamaCpp.getVocabSize()).toInt()
-                                    coroutineScope.launch { HiPSDataStore.writeSettings() }
+                                        // Update DataStore
+                                        Settings.temperature = it.roundToInt() / 10f
+                                        coroutineScope.launch { HiPSDataStore.writeSettings() }
+                                    }
                                 },
-                                valueRange = 0f..100f,
-                                steps = 99
+                                valueRange = 0f..20f,
+                                steps = 19
                             )
 
-                            Spacer(modifier = modifier.height(8.dp))
-
                             Text(
-                                text = "${(selectedTopK.toFloat() / LlamaCpp.getVocabSize() * 100).toInt()}% of the vocabulary",
+                                text = "$selectedTemperature",
                                 modifier = modifier.align(Alignment.CenterHorizontally)
                             )
 
-                            Spacer(modifier = modifier.height(16.dp))
+                            // Show settings specific to LLM only when it is in memory
+                            if (isInMemory) {
+                                // Top k
+                                Text(text = "Set the top k for token sampling. This is the number of most likely tokens from the LLM's vocabulary to consider. 100% (= ${LlamaCpp.getVocabSize()} tokens) is recommended.")
 
-                            // Precision
-                            Text(
-                                text = "Set the precision for token sampling. Recommended is ⌈log₂($selectedTopK)⌉ = "
-                                        + if (selectedTopK > 0) { "${ceil(log2(selectedTopK.toFloat())).toInt()}" } else { "n/a" }
-                                        + " bits. Other values can be more efficient, but extremes produce long cover texts."
-                            )
+                                // Again, do int conversion here as slider only allows floats
+                                // Display top k in %, but store absolute number internally
+                                Slider(
+                                    value = (selectedTopK.toFloat() / LlamaCpp.getVocabSize() * 100),
+                                    onValueChange = {
+                                        // Update state variable
+                                        selectedTopK = (it / 100 * LlamaCpp.getVocabSize()).toInt()
 
-                            Spacer(modifier = modifier.height(16.dp))
+                                        // Update DataStore
+                                        Settings.topK = (it / 100 * LlamaCpp.getVocabSize()).toInt()
+                                        coroutineScope.launch { HiPSDataStore.writeSettings() }
+                                    },
+                                    valueRange = 0f..100f,
+                                    steps = 99
+                                )
 
-                            // Again, do int conversion here as slider only allows floats
-                            // Don't expose 64 bit precision from Arithmetic compression in UI for steganography, encoding would take ages and offer no benefit with vocabulary sizes of current LLMs
-                            // Using 64 bits internally also avoids integer overflows at 31-32 bits
-                            Slider(
-                                value = selectedPrecision.toFloat(),
-                                onValueChange = {
-                                    // Update state variable
-                                    selectedPrecision = it.toInt()
+                                Text(
+                                    text = "${(selectedTopK.toFloat() / LlamaCpp.getVocabSize() * 100).toInt()}% of the vocabulary",
+                                    modifier = modifier.align(Alignment.CenterHorizontally)
+                                )
 
-                                    // Update DataStore
-                                    Settings.precision = it.toInt()
-                                    coroutineScope.launch { HiPSDataStore.writeSettings() }
-                                },
-                                valueRange = 0f..32f,
-                                steps = 31
-                            )
+                                // Precision
+                                Text(
+                                    text = "Set the precision for token sampling. Recommended is ⌈log₂($selectedTopK)⌉ = "
+                                            + if (selectedTopK > 0) { "${ceil(log2(selectedTopK.toFloat())).toInt()}" } else { "n/a" }
+                                            + " bits. Other values can be more efficient, but extremes produce long cover texts."
+                                )
 
-                            Spacer(modifier = modifier.height(8.dp))
+                                // Again, do int conversion here as slider only allows floats
+                                // Don't expose 64 bit precision from Arithmetic compression in UI for steganography, encoding would take ages and offer no benefit with vocabulary sizes of current LLMs
+                                // Using 64 bits internally also avoids integer overflows at 31-32 bits
+                                Slider(
+                                    value = selectedPrecision.toFloat(),
+                                    onValueChange = {
+                                        // Update state variable
+                                        selectedPrecision = it.toInt()
 
-                            Text(
-                                text = "$selectedPrecision " + if (selectedPrecision == 1) "bit" else "bits",
-                                modifier = modifier.align(Alignment.CenterHorizontally)
-                            )
-                        }
-                        else {
-                            Text(
-                                text = "Load the LLM into memory to see more settings here.",
-                                fontStyle = FontStyle.Italic
-                            )
+                                        // Update DataStore
+                                        Settings.precision = it.toInt()
+                                        coroutineScope.launch { HiPSDataStore.writeSettings() }
+                                    },
+                                    valueRange = 0f..32f,
+                                    steps = 31
+                                )
+
+                                Text(
+                                    text = "$selectedPrecision " + if (selectedPrecision == 1) "bit" else "bits",
+                                    modifier = modifier.align(Alignment.CenterHorizontally)
+                                )
+                            }
+                            else {
+                                Text(
+                                    text = "Load the LLM into memory to see more settings here.",
+                                    fontStyle = FontStyle.Italic
+                                )
+                            }
                         }
                     }
                     /*
@@ -585,41 +546,37 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                     }
                     */
                     SteganographyMode.Huffman -> {
-                        Text(text = "Set the number of bits to encode per cover text token. Higher is more efficient, but less coherent.")
+                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                            Text(text = "Set the number of bits to encode per cover text token. Higher is more efficient, but less coherent.")
 
-                        Spacer(modifier = modifier.height(16.dp))
+                            // Again, do int conversion here as slider only allows floats
+                            Slider(
+                                value = selectedBitsPerToken.toFloat(),
+                                onValueChange = {
+                                    // Update state variable
+                                    selectedBitsPerToken = it.toInt()
 
-                        // Again, do int conversion here as slider only allows floats
-                        Slider(
-                            value = selectedBitsPerToken.toFloat(),
-                            onValueChange = {
-                                // Update state variable
-                                selectedBitsPerToken = it.toInt()
+                                    // Update DataStore
+                                    Settings.bitsPerToken = it.toInt()
+                                    coroutineScope.launch { HiPSDataStore.writeSettings() }
+                                },
+                                valueRange = 1f..4f,
+                                steps = 2
+                            )
 
-                                // Update DataStore
-                                Settings.bitsPerToken = it.toInt()
-                                coroutineScope.launch { HiPSDataStore.writeSettings() }
-                            },
-                            valueRange = 1f..4f,
-                            steps = 2
-                        )
-
-                        Spacer(modifier = modifier.height(8.dp))
-
-                        Text(
-                            text = "$selectedBitsPerToken " + if (selectedBitsPerToken == 1) "bit/token" else "bits/token",
-                            modifier = modifier.align(Alignment.CenterHorizontally)
-                        )
+                            Text(
+                                text = "$selectedBitsPerToken " + if (selectedBitsPerToken == 1) "bit/token" else "bits/token",
+                                modifier = modifier.align(Alignment.CenterHorizontally)
+                            )
+                        }
                     }
                 }
             }
         }
 
-        Spacer(modifier = modifier.height(16.dp))
-
         // Reset settings
         Row(
-            modifier = modifier.fillMaxWidth(0.9f)
+            modifier = modifier.fillMaxWidth()
         ) {
             Icon(
                 imageVector = Icons.Outlined.Restore,
@@ -628,7 +585,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
 
             Spacer(modifier = modifier.width(16.dp))
 
-            Column {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Text(
                     text = "Reset settings",
                     fontSize = 18.sp,
@@ -637,11 +594,7 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
 
                 Text(text = "Reset settings to their default values.")
 
-                Spacer(modifier = modifier.height(16.dp))
-
                 Text(text = "If the LLM is in memory, this finds reasonable values for the settings that are specific to it.")
-
-                Spacer(modifier = modifier.height(16.dp))
 
                 Row(
                     modifier = modifier.fillMaxWidth(),
@@ -706,17 +659,13 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
             }
         }
 
-        Spacer(modifier = modifier.height(16.dp))
-
         HorizontalDivider()
-
-        Spacer(modifier = modifier.height(16.dp))
 
         // Author credits
         // Make the whole row clickable instead of just the text for better accessibility
         Row(
             modifier = modifier
-                .fillMaxWidth(0.9f)
+                .fillMaxWidth()
                 .clickable(
                     onClick = {
                         // Open email app and create draft with subject "HiPS"
@@ -743,12 +692,10 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
             }
         }
 
-        Spacer(modifier = modifier.height(16.dp))
-
         // Link to source code
         Row(
             modifier = modifier
-                .fillMaxWidth(0.9f)
+                .fillMaxWidth()
                 .clickable(
                     onClick = {
                         // Open the repo website
@@ -774,8 +721,6 @@ fun SettingsScreen(navController: NavController, modifier: Modifier) {
                 Text(text = "github.com/tobiasvonderheidt/hips")
             }
         }
-
-        Spacer(modifier = modifier.height(32.dp))
     }
 }
 


### PR DESCRIPTION
This pull request addresses the excessive vertical spacing across the Home, Settings, and Conversation screens, resulting in a more compact, consistent, and user-friendly layout.


Problem: The previous layouts used large, hardcoded Spacer components, leading to an inefficient use of screen space and an inconsistent feel between different UI elements.

Solution: The layouts for the key screens were refactored to reduce whitespace and improve visual consistency.

Key Changes:
HomeScreen.kt & SettingsScreen.kt:
◦Replaced all manual Spacer components with a single verticalArrangement = Arrangement.spacedBy(8.dp) in the root Column. This creates a much smaller and more consistent gap between all elements.
◦Added modifier.padding(horizontal = 16.dp) to the root Column to establish a consistent side margin.
◦Widened input fields to use fillMaxWidth() for better space utilization.

ConversationScreen.kt:
◦Removed Spacers that were creating large gaps between message bubbles in the chat list.
◦Reduced padding within message bubbles and other UI elements.
◦Decreased the size of header elements and the spacing between them for a tighter look.

These changes significantly improve the information density and overall aesthetic of the application.